### PR TITLE
Fix SpriteHelper alpha masking

### DIFF
--- a/UnityPy/export/SpriteHelper.py
+++ b/UnityPy/export/SpriteHelper.py
@@ -90,7 +90,8 @@ def get_image_from_sprite(m_Sprite) -> Image:
             draw.polygon(triangle, fill=1)
 
         # apply the mask
-        sprite_image.putalpha(mask)
+        empty_img = Image.new(sprite_image.mode, sprite_image.size, color=0)
+        sprite_image = Image.composite(sprite_image, empty_img, mask)
 
     return sprite_image.transpose(Image.FLIP_TOP_BOTTOM)
 

--- a/UnityPy/export/SpriteHelper.py
+++ b/UnityPy/export/SpriteHelper.py
@@ -90,8 +90,14 @@ def get_image_from_sprite(m_Sprite) -> Image:
             draw.polygon(triangle, fill=1)
 
         # apply the mask
-        empty_img = Image.new(sprite_image.mode, sprite_image.size, color=0)
-        sprite_image = Image.composite(sprite_image, empty_img, mask)
+        if sprite_image.mode == "RGBA":
+            # the image already has an alpha channel,
+            # so we have to use composite to keep it 
+            empty_img = Image.new(sprite_image.mode, sprite_image.size, color=0)
+            sprite_image = Image.composite(sprite_image, empty_img, mask)
+        else:
+            # add mask as alpha-channel to keep the polygon clean
+            sprite_image.putalpha(mask)
 
     return sprite_image.transpose(Image.FLIP_TOP_BOTTOM)
 


### PR DESCRIPTION
Use composite instead of putalpha to preserve transparency from the original texture + alpha_texture image.
Basically just reverting only the putalpha line from https://github.com/K0lb3/UnityPy/commit/5fa465ad8b03dbda04f5dced2eb6440a8433f547#diff-2349e8a318085de3cca91bec8e7ec0e0