### PR TITLE
Better AssetBatchConverter

### DIFF
--- a/UnityPy/AssetsManager.py
+++ b/UnityPy/AssetsManager.py
@@ -3,7 +3,7 @@ import logging
 import os
 from zipfile import ZipFile
 
-from .EndianBinaryReader import EndianBinaryReader
+from .streams.EndianBinaryReader import EndianBinaryReader
 from .Progress import Progress
 from .files import BundleFile, SerializedFile, WebFile
 from .helpers import ImportHelper

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -1,11 +1,25 @@
 import io
 import os
+from collections import Counter
+from collections.abc import Callable
 from zipfile import ZipFile
 
 from . import files
 from .enums import FileType
 from .helpers import ImportHelper
 
+"""
+ Number of dirs to ignore:
+ e.g. IGNOR_DIR_COUNT = 2 will reduce
+ 'assets/assetbundles/images/story_picture/small/15.png'
+ to
+ 'images/story_picture/small/15.png'
+"""
+IGNORE_DIR_COUNT = 0
+DEFAULT_TYPES = ['MonoBehaviour', 'Texture2D', 'TextAsset']
+
+def default_progress(skip_progress):
+    return skip_progress
 
 class Environment:
     files: dict
@@ -20,6 +34,9 @@ class Environment:
         self.assets = {}
         self.resources = {}
         self.path = "."
+        self.out_path = os.path.join(os.getcwd(), "output")
+        self.ignore_dir_lvls = IGNORE_DIR_COUNT
+        self.progress_function = default_progress
 
         if args:
             for arg in args:
@@ -66,7 +83,51 @@ class Environment:
             self.load_file(f)
             # self.Progress.report(i + 1, len(self.import_files))
 
-    def load_file(self, full_name: str = "", data=None):
+    def save(self, pack="none"):
+        """ Saves all changed assets.
+            Mark assets as changed using `.mark_changed()`.
+            pack = "none" (default) or "lz4"
+        """
+        for f in self.files:
+            if self.files[f].is_changed:
+                with open(os.path.join(self.out_path, os.path.basename(f)), 'wb') as out:
+                    out.write(self.files[f].save(packer=pack))
+
+    def process(self, obj_modify: Callable, types: list=DEFAULT_TYPES, **kwargs):
+        """Accept modification function `obj_modify => obj_modify(obj, asset, local_path) to modify `types` """
+        for asset in self.progress_function(self.assets):
+            current_asset = self.assets[asset]
+
+            if not current_asset.container: continue # TODO: fix it
+
+            # check which mode we will have to use
+            num_containers = sum(1 for obj in current_asset.container.values() if obj.type in types)
+            num_objects = sum(1 for obj in current_asset.objects.values() if obj.type in types)
+            if num_containers == 0 and num_objects == 0: continue
+
+            # check if container contains all important assets, if yes, just ignore the container
+            local_path = ''
+            if num_objects <= num_containers * 2:
+                for asset_path, obj in current_asset.container.items():
+                    try:
+                        local_path = os.path.join(*asset_path.split('/')[self.ignore_dir_lvls:])
+                    except:
+                        pass
+                    if obj.type in types:
+                        obj_modify(obj, asset, local_path=local_path, **kwargs)
+            else: # otherwise use the container to generate a path for the normal objects
+                extracted = []
+                # find the most common path
+                occurence_count = Counter(os.path.splitext(asset_path)[0] for asset_path in current_asset.container.keys())
+                try:
+                    local_path = os.path.join(*occurence_count.most_common(1)[0][0].split('/')[self.ignore_dir_lvls:])
+                except:
+                    pass
+                for obj in current_asset.objects.values():
+                    if obj.path_id not in extracted and obj.type in types:
+                        extracted.extend(obj_modify(obj, asset, local_path=local_path, **kwargs))
+
+    def load_file(self, full_name: str = "", data = None):
         typ, reader = ImportHelper.check_file_type(data if data else full_name)
         if not full_name:
             full_name = str(data[:256])

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
 	long_description_content_type="text/markdown",
 	url="https://github.com/K0lb3/UnityPy",
 	download_url="https://github.com/K0lb3/UnityPy/tarball/master",
-	keywords=['Unity', 'unitypack', 'UnityPy', "unpack"],
+	keywords=["Unity", "unitypack", "UnityPy", "unpack", "game tools"],
 	classifiers=[
 		"License :: OSI Approved :: MIT License",
 		"Operating System :: OS Independent",
@@ -24,6 +24,7 @@ setuptools.setup(
 		"Programming Language :: Python :: 3",
 		"Programming Language :: Python :: 3.6",
 		"Programming Language :: Python :: 3.7",
+		"Programming Language :: Python :: 3.8",
 		"Topic :: Multimedia :: Graphics",
 	],
 	install_requires=[
@@ -31,6 +32,7 @@ setuptools.setup(
 		"brotli",
 		"Pillow",
 		"fsb5",
+		"tqdm",
 		"texture2ddecoder"
 	]
 )


### PR DESCRIPTION
There are fixes allowing reserialization of `MonoBehaviour`, `Texture2D` and `Sprite`. And updated `AssetBatchConverter`, also moved part of it to `Environment` as it's repeated in extraction/repacking. 
The stuff removed from `AssetsManager` is inconsistent with `Environment`, please check it (it doesn't return/save refs to resources inside the asset).