### PR TITLE
AudioClipConverter: support direct OGG and WAV content (no FSB5)

### DIFF
--- a/UnityPy/export/AudioClipConverter.py
+++ b/UnityPy/export/AudioClipConverter.py
@@ -15,12 +15,21 @@ def extract_audioclip_samples(audio) -> dict:
 	:return: {filename : sample(bytes)}
 	:rtype: dict
 	"""
-    ret = {}
 
     if not audio.m_AudioData:
         # eg. StreamedResource not available
         return {}
 
+    magic = memoryview(audio.m_AudioData)[:4]
+    if magic == b'OggS':
+        return {'%s.ogg' % audio.name: audio.m_AudioData}
+    elif magic == b'RIFF':
+        return {'%s.wav' % audio.name: audio.m_AudioData}
+    return _extract_fsb(audio)
+
+
+def _extract_fsb(audio) -> dict:
+    ret = {}
     af = FSB5(audio.m_AudioData)
     for i, sample in enumerate(af.samples):
         if i > 0:


### PR DESCRIPTION
For some games, there is no FSB data, the audio file is directly there.

Closes #20 