### PR TITLE
Change how enums are created, fixes K0lb3/UnityPy#67

### DIFF
--- a/UnityPy/classes/AnimationClip.py
+++ b/UnityPy/classes/AnimationClip.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 from .NamedObject import NamedObject
 from .PPtr import PPtr
-from ..enums import ClassIDType
+from ..enums import ClassIDType, makeClassID
 from ..math import Quaternion, Vector3
 from ..streams import EndianBinaryReader
 
@@ -225,7 +225,7 @@ class FloatCurve:
         self.curve = AnimationCurve(reader, reader.read_float)  # Float
         self.attribute = reader.read_aligned_string()
         self.path = reader.read_aligned_string()
-        self.classID = ClassIDType(reader.read_int())
+        self.classID = makeClassID(reader.read_int())
         self.script = PPtr(reader)  # MonoScript
 
 
@@ -496,9 +496,9 @@ class GenericBinding:
         self.attribute = reader.read_u_int()
         self.script = PPtr(reader)  # Object
         if version >= (5, 6):  # 5.6 and up
-            self.typeID = ClassIDType(reader.read_int())
+            self.typeID = makeClassID(reader.read_int())
         else:
-            self.typeID = ClassIDType(reader.read_u_short())
+            self.typeID = makeClassID(reader.read_u_short())
         self.customType = reader.read_byte()
         self.isPPtrCurve = reader.read_byte()
         reader.align_stream()

--- a/UnityPy/enums/BuildTarget.py
+++ b/UnityPy/enums/BuildTarget.py
@@ -39,12 +39,31 @@ class BuildTarget(IntEnum):
     Switch = 38
     NoTarget = -2
 
-    @classmethod
-    def _missing_(cls, value):
-        ret = BuildTarget.UnknownPlatform
-        ret._value = value
-        return ret
+    def __str__(self):
+        return self.name
 
-    @property
-    def value(self):
-        return getattr(self, "_value", self._value_)
+    def __format__(self, fmt):
+        return self.name
+
+    def __eq__(self, value):
+        if isinstance(value, str):
+            return self.name == value
+        elif isinstance(value, BuildTarget):
+            return self._value_ == value._value_
+        elif isinstance(value, int):
+            if self.has_value(value):
+                return self._value_ == value
+            return False
+        return self._value_ == value
+
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_ 
+     
+
+def makeBuildTarget(_bt):
+    if isinstance(_bt, BuildTarget):
+        return _bt
+    elif BuildTarget.has_value(_bt):
+        return BuildTarget(_bt)
+    return _bt

--- a/UnityPy/enums/ClassIDType.py
+++ b/UnityPy/enums/ClassIDType.py
@@ -375,18 +375,32 @@ class ClassIDType(IntEnum):
     def __str__(self):
         return self.name
 
+    def __format__(self, fmt):
+        return self.name
+
     def __eq__(self, value):
         if isinstance(value, str):
             return self.name == value
-        else:
-            return self.value == value
+        elif isinstance(value, ClassIDType):
+            return self._value_ == value._value_
+        elif isinstance(value, int):
+            if self.has_value(value):
+                return self._value_ == value
+            elif self._value_ == -1 and not self.has_value(value):
+                return True
+            return False
+        return self._value_ == value
 
     @classmethod
-    def _missing_(cls, value):
-        ret = ClassIDType.UnknownType
-        ret._value = value
-        return ret
+    def has_value(cls, value):
+        return value in cls._value2member_map_ 
+     
 
-    @property
-    def value(self):
-        return getattr(self, "_value", self._value_)
+def makeClassID(_cid):
+    if isinstance(_cid, ClassIDType):
+        return _cid
+    elif _cid == -1:
+        return ClassIDType.UnknownType
+    elif ClassIDType.has_value(_cid):
+        return ClassIDType(_cid)
+    return _cid

--- a/UnityPy/enums/__init__.py
+++ b/UnityPy/enums/__init__.py
@@ -1,6 +1,6 @@
 from .Audio import AudioType, AudioCompressionFormat, AUDIO_TYPE_EXTEMSION
-from .BuildTarget import BuildTarget
-from .ClassIDType import ClassIDType
+from .BuildTarget import BuildTarget, makeBuildTarget
+from .ClassIDType import ClassIDType, makeClassID
 from .FileType import FileType
 from .TextureFormat import TextureFormat
 from .SpriteMeshType import SpriteMeshType

--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -1,4 +1,4 @@
-from ..enums import ClassIDType
+from ..enums import ClassIDType, makeClassID
 from . import SerializedFile
 from .. import classes
 from ..streams import EndianBinaryReader, EndianBinaryWriter
@@ -67,7 +67,7 @@ class ObjectReader:
             self.serialized_type = typ
             self.class_id = typ.class_id
 
-        self.type = ClassIDType(self.class_id)
+        self.type = makeClassID(self.class_id)
 
         if header.version < 11:
             self.is_destroyed = reader.read_u_short()

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 from . import File, ObjectReader
-from ..enums import BuildTarget, ClassIDType, CommonString
+from ..enums import BuildTarget, makeBuildTarget, ClassIDType, CommonString
 from ..streams import EndianBinaryReader, EndianBinaryWriter
 
 RECURSION_LIMIT = sys.getrecursionlimit()
@@ -237,7 +237,7 @@ class SerializedFile(File.File):
 
         if header.version >= 8:
             self._m_target_platform = reader.read_int()
-            self.target_platform = BuildTarget(self._m_target_platform)
+            self.target_platform = makeBuildTarget(self._m_target_platform)
 
         if header.version >= 13:
             self._enable_type_tree = reader.read_boolean()


### PR DESCRIPTION
Is it viable this way? It's better if the value stores original data if there is no corresponding enum field so we can later write it back as is.