### PR TITLE
fix TypeTreeError prints

### DIFF
--- a/UnityPy/__init__.py
+++ b/UnityPy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.23"
+__version__ = "1.7.24"
 
 from .environment import Environment
 

--- a/UnityPy/classes/MonoBehaviour.py
+++ b/UnityPy/classes/MonoBehaviour.py
@@ -14,7 +14,7 @@ class MonoBehaviour(Behaviour):
             try:
                 self.read_typetree()
             except TypeTreeError as e:
-                print("Failed to read TypeTree:\n", e.message)
+                print("Failed to read TypeTree:\n", e)
                 self.assets_file._enable_type_tree = False
 
     def save(self, writer: EndianBinaryWriter = None, raw_data: bytes = None):

--- a/UnityPy/classes/Object.py
+++ b/UnityPy/classes/Object.py
@@ -50,7 +50,7 @@ class Object(object):
         try:
             tree = self.reader.read_typetree(nodes)
         except TypeTreeError as e:
-            print("Failed to read TypeTree:\n", e.message)
+            print("Failed to read TypeTree:\n", e)
             return {}
         self.type_tree = NodeHelper(tree, self.assets_file)
         return tree

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -81,7 +81,7 @@ class Environment:
         except Exception as e:
             # just to be sure
             # cuz the SerializedFile detection isn't perfect
-            print("Error loading, reverting to EndianBinaryReader:\n", e.message)
+            print("Error loading, reverting to EndianBinaryReader:\n", e)
             return EndianBinaryReader(stream)
 
     def load_zip_file(self, value):


### PR DESCRIPTION
Exception.message is invalid
str(Exception) instead returns the message