### PR TITLE
Make PlayerSettings editable

### DIFF
--- a/UnityPy/classes/PlayerSettings.py
+++ b/UnityPy/classes/PlayerSettings.py
@@ -1,5 +1,5 @@
 from .Object import Object
-
+from ..streams import EndianBinaryWriter
 
 class PlayerSettings(Object):
     def __init__(self, reader):
@@ -27,3 +27,37 @@ class PlayerSettings(Object):
             self.accelerometerFrequency = reader.read_int()
         self.companyName = reader.read_aligned_string()
         self.productName = reader.read_aligned_string()
+        self.the_rest = reader.read_the_rest(reader.byte_size, reader.byte_start)
+
+    def save(self, writer: EndianBinaryWriter = None):
+        if writer is None:
+            writer = EndianBinaryWriter(endian=self.reader.endian)
+
+        super().save(writer, intern_call=True)
+        version = self.version
+        if version >= (5, 4):  # 5.4.0 nad up
+            writer.write_bytes(self.productGUID)
+
+        writer.write_boolean(self.AndroidProfiler)
+        # bool AndroidFilterTouchesWhenObscured 2017.2 and up
+        # bool AndroidEnableSustainedPerformanceMode 2018 and up
+        writer.align_stream()
+        writer.write_int(self.defaultScreenOrientation)
+        writer.write_int(self.targetDevice)
+        if version < (5, 3):  # 5.3 down
+            if version < (5,):  # 5.0 down
+                writer.write_int(self.targetPlatform)  # 4.0 and up targetGlesGraphics
+                if version >= (4, 6):  # 4.6 and up
+                    writer.write_int(self.targetIOSGraphics)
+            writer.write_int(self.targetResolution)
+        else:
+            writer.write_boolean(self.useOnDemandResources)
+            writer.align_stream()
+        if version >= (3, 5):  # 3.5 and up
+            writer.write_int(self.accelerometerFrequency)
+        writer.write_aligned_string(self.companyName)
+        writer.write_aligned_string(self.productName)
+        writer.write_bytes(self.the_rest)
+
+        self.set_raw_data(writer.bytes)
+


### PR DESCRIPTION
Just as the title says.
I didn't need the previously non-unserialized fields of `PlayerSettings` of new versions so they're restored by binary-reading and writing them back as is. If anyone completes the class later it would be even better.