### PR TITLE
Fix Big Big Big Bug

### DIFF
--- a/UnityPy/helpers/ImportHelper.py
+++ b/UnityPy/helpers/ImportHelper.py
@@ -58,7 +58,7 @@ def merge_split_assets(path: str, all_directories: bool = False):
                     if not os.path.isfile(split_part):
                         break
                     f.write(open(split_part, "rb").read())
-
+                    i += 1
 
 def processing_split_files(select_file: list) -> list:
     split_files = [fp for fp in select_file if ".split" in fp]


### PR DESCRIPTION

When merging multiple splitx files into the one file, the wrong code logic caused the disk to be full