### PR TITLE
Remove unused tkinter import

### DIFF
--- a/UnityPy/__init__.py
+++ b/UnityPy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 
 from .environment import Environment
 

--- a/UnityPy/classes/GameObject.py
+++ b/UnityPy/classes/GameObject.py
@@ -1,4 +1,3 @@
-from tkinter.messagebox import NO
 from .EditorExtension import EditorExtension
 from .PPtr import PPtr
 from ..enums import ClassIDType


### PR DESCRIPTION
This caused UnityPy to crash on import if tkinter was not installed.
The import was originally added in 7a45608bfc34bee6c2267a528274fd0c961d6f39