### PR TITLE
CI: fix names of linux wheels

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,19 +44,6 @@ jobs:
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: pytest -v -s {package}/tests
 
-    - name: Rename Linux wheels to ManyLinux
-      if: runner.os == 'Linux'
-      uses: jannekem/run-python-script-action@v1
-      with:
-        script: |
-          import os
-          wheeldir = "./wheelhouse"
-          print(os.listdir(wheeldir))
-          for f in os.listdir(wheeldir):
-              fp = os.path.join(wheeldir, f)
-              print(fp,"->",fp.replace("linux", "manylinux2014"))
-              os.rename(fp, fp.replace("linux", "manylinux2014"))
-
     - name: Publish to PyPI
       if: success() && github.event_name == 'push' && env.TWINE_PASSWORD != '' && github.ref == 'refs/heads/master'
       env:


### PR DESCRIPTION
The last few releases of UnityPy are missing linux wheels on PyPI. Digging into the GitHub Actions Logs I noticed that, at least for 1.9.14, the wheels build correctly, but they fail to upload on PyPI due to an `unsupported platform tag 'manymanylinux2014_2_17_aarch64'` (the correct tag should be `manylinux_2_17_aarch64`). 

<details>
<summary>Logs from https://github.com/K0lb3/UnityPy/runs/7925016550?check_suite_focus=true</summary>

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Binary wheel                                                           
         'unitypy-1.9.14-cp37-cp37m-manymanylinux2014_2_17_aarch64.whl' has an  
         unsupported platform tag 'manymanylinux2014_2_17_aarch64'.             
```

</details>

Simply removing the renaming step from the workflow file seems to fix this.