### PR TITLE
Changed BC5 image mode argument

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -254,7 +254,7 @@ CONV_TABLE = {
 (  TF.YUY2,                                                                                     ),
 (  TF.RGB9e5Float,                                                                              ),
 (  TF.BC4,                 pillow,  "L",     "bcn",       4                                     ),
-(  TF.BC5,                 pillow,  "RGBA",  "bcn",       5                                     ),
+(  TF.BC5,                 pillow,  "RGB",   "bcn",       5                                     ),
 (  TF.BC6H,                pillow,  "RGBA",  "bcn",       6                                     ),
 (  TF.BC7,                 pillow,  "RGBA",  "bcn",       7                                     ),
 (  TF.DXT1Crunched,        pillow,  "RGBA",  "bcn",       1                                     ),


### PR DESCRIPTION
BC5 mode "RGBA" -> "RGB" in order for PIL to build a proper decoder for the image

Based on PIL Pull request [#5501](https://github.com/python-pillow/Pillow/pull/5501) BC5 should have a image mode "RGB" instead of "RGBA"