### PR TITLE
Add filter functionality to extractor

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -108,36 +108,38 @@ def extract_assets(
         container = sorted(env.container, lambda x: defaulted_export_index(x[1].type))
         for obj_path, obj in container:
             # The filter here can only access metadata. The same filter may produce a different result later in extract_obj after obj.read()
-            if (not asset_filter) or asset_filter(obj):
-                # the check of the various sub directories is required to avoid // in the path
-                obj_dest = os.path.join(
-                    dst,
-                    *(x for x in obj_path.split("/")[:ignore_first_container_dirs] if x),
+            if asset_filter is not None and not asset_filter(obj):
+                continue
+            # the check of the various sub directories is required to avoid // in the path
+            obj_dest = os.path.join(
+                dst,
+                *(x for x in obj_path.split("/")[:ignore_first_container_dirs] if x),
+            )
+            os.makedirs(os.path.dirname(obj_dest), exist_ok=True)
+            exported.extend(
+                export_obj(
+                    obj,
+                    obj_dest,
+                    append_path_id=append_path_id,
+                    export_unknown_as_typetree=export_unknown_as_typetree,
                 )
-                os.makedirs(os.path.dirname(obj_dest), exist_ok=True)
-                exported.extend(
-                    export_obj(
-                        obj,
-                        obj_dest,
-                        append_path_id=append_path_id,
-                        export_unknown_as_typetree=export_unknown_as_typetree,
-                    )
-                )
+            )
 
     else:
         objects = sorted(env.objects, lambda x: defaulted_export_index(x.type))
         for obj in objects:
-            if (not asset_filter) or asset_filter(obj):
-                if obj.path_id not in exported:
-                    exported.extend(
-                        export_obj(
-                            obj,
-                            dst,
-                            append_name=True,
-                            append_path_id=append_path_id,
-                            export_unknown_as_typetree=export_unknown_as_typetree,
-                        )
+            if asset_filter is not None and not asset_filter(obj):
+                continue
+            if obj.path_id not in exported:
+                exported.extend(
+                    export_obj(
+                        obj,
+                        dst,
+                        append_name=True,
+                        append_path_id=append_path_id,
+                        export_unknown_as_typetree=export_unknown_as_typetree,
                     )
+                )
 
     return exported
 


### PR DESCRIPTION
This PR adds a new optional parameter to extract_assets and export_obj that will skip exporting objects based on a provided filter function.

Here is an example function from my real use case, which only exports audio clips over a certain length with names that match one of a list of file glob patterns and does not match any of another list of file glob patterns.

```python3
def asset_filter(obj):
    # Only export AudioClip assets
    if obj.type != ClassIDType.AudioClip:
        # incorrect type
        return False
    # A filter is called twice for each object
    # First, during extract_assets, when only metadata has been loaded
    # Second, during extract_obj, after the asset has been .read()
    # The checks here for m_Length and name will be skipped during the first pass
    if obj.m_Length is not None and obj.m_Length < args.minduration:
        # too short
        return False
    if obj.name is not None:
        for excludespec in assetsexcludespec:
            if excludespec and fnmatch.fnmatch(obj.name, excludespec):
                # excluded by an excludespec match
                return False
        for filespec in assetsfilespec:
            if filespec and fnmatch.fnmatch(obj.name, filespec):
                # included by a filespec match
                return True
        # not included by any filespec match
        return False
    # correct type, length and name checks skipped because they aren't available
    return True
```

The diff is a lot cleaner with whitespace changes omitted. https://github.com/K0lb3/UnityPy/pull/133/files?w=1