### PR TITLE
Create `list_container` as `container` alternative for multiple objects with the same container path

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ One of these objects can be an AssetBundle, which contains a file path for some 
 
 All objects can be found in the ``.objects`` dict - ``{ID : object}``.
 
-The objects with a file path can be found in the ``.container`` dict - ``{path : [object]}``.
+The objects with a file path can be found in the ``.container`` dict - ``{path : object}`` or ``.listContainer`` dict - ``{path : [object]}``.
 
 ### [Object](UnityPy/files/ObjectReader.py)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ One of these objects can be an AssetBundle, which contains a file path for some 
 
 All objects can be found in the ``.objects`` dict - ``{ID : object}``.
 
-The objects with a file path can be found in the ``.container`` dict - ``{path : object}`` or ``.listContainer`` dict - ``{path : [object]}``.
+The objects with a file path can be found in the ``.container`` dict - ``{path : object}`` or ``.list_container`` dict - ``{path : [object]}``.
 
 ### [Object](UnityPy/files/ObjectReader.py)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ One of these objects can be an AssetBundle, which contains a file path for some 
 
 All objects can be found in the ``.objects`` dict - ``{ID : object}``.
 
-The objects with a file path can be found in the ``.container`` dict - ``{path : object}``.
+The objects with a file path can be found in the ``.container`` dict - ``{path : [object]}``.
 
 ### [Object](UnityPy/files/ObjectReader.py)
 

--- a/UnityPy/classes/AssetBundle.py
+++ b/UnityPy/classes/AssetBundle.py
@@ -17,11 +17,11 @@ class AssetBundle(NamedObject):
         self.m_PreloadTable = [PPtr(reader) for _ in range(preload_table_size)]
         container_size = reader.read_int()
         self.m_Container = {}
-        self.listContainer = defaultdict(list)
+        self.list_container = defaultdict(list)
         # TODO - m_Container is a multi-dict, multiple values can have the same key
-        # listContainer is a dict of list that workaround the issue temporarily before version 2
+        # list_container is a dict of list that workaround the issue temporarily before version 2
         for i in range(container_size):
             key = reader.read_aligned_string()
             info = AssetInfo(reader)
             self.m_Container[key] = info
-            self.listContainer[key].append(info)
+            self.list_container[key].append(info)

--- a/UnityPy/classes/AssetBundle.py
+++ b/UnityPy/classes/AssetBundle.py
@@ -16,7 +16,12 @@ class AssetBundle(NamedObject):
         preload_table_size = reader.read_int()
         self.m_PreloadTable = [PPtr(reader) for _ in range(preload_table_size)]
         container_size = reader.read_int()
-        self.m_Container = defaultdict(list)
+        self.m_Container = {}
+        self.listContainer = defaultdict(list)
+        # TODO - m_Container is a multi-dict, multiple values can have the same key
+        # listContainer is a dict of list that workaround the issue temporarily before version 2
         for i in range(container_size):
             key = reader.read_aligned_string()
-            self.m_Container[key].append(AssetInfo(reader))
+            info = AssetInfo(reader)
+            self.m_Container[key] = info
+            self.listContainer[key].append(info)

--- a/UnityPy/classes/AssetBundle.py
+++ b/UnityPy/classes/AssetBundle.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from .NamedObject import NamedObject
 from .PPtr import PPtr
 
@@ -15,8 +16,7 @@ class AssetBundle(NamedObject):
         preload_table_size = reader.read_int()
         self.m_PreloadTable = [PPtr(reader) for _ in range(preload_table_size)]
         container_size = reader.read_int()
-        self.m_Container = {}
-        # TODO - m_Container is a multi-dict, multiple values can have the same key
+        self.m_Container = defaultdict(list)
         for i in range(container_size):
             key = reader.read_aligned_string()
-            self.m_Container[key] = AssetInfo(reader)
+            self.m_Container[key].append(AssetInfo(reader))

--- a/UnityPy/classes/ResourceManager.py
+++ b/UnityPy/classes/ResourceManager.py
@@ -8,17 +8,27 @@ class ResourceManager(Object):
     def __init__(self, reader):
         super().__init__(reader)
         m_ContainerSize = reader.read_int()
-        self.m_Container = defaultdict(list)
+        self.m_Container = {}
+        self.listContainer = defaultdict(list)
         for _ in range(m_ContainerSize):
-            self.m_Container[reader.read_aligned_string()].append(PPtr(reader))
+            key = reader.read_aligned_string()
+            self.m_Container[key] = PPtr(reader)
+            self.listContainer[key].append(PPtr(reader))
 
-    def save(self, writer: EndianBinaryWriter = None):
+    def save(self, writer: EndianBinaryWriter = None, multipleObjectsPerContainer: bool = False):
         if not writer:
             writer = EndianBinaryWriter(endian=self.reader.endian)
         super().save(writer, intern_call=True)
-        writer.write_int(sum([len(vals) for vals in self.m_Container.values()]))
-        for key, vals in self.m_Container.items():
-            for val in vals:
+        if multipleObjectsPerContainer:
+            writer.write_int(sum([len(vals) for vals in self.listContainer.values()]))
+            for key, vals in self.listContainer.items():
+                for val in vals:
+                    writer.write_aligned_string(key)
+                    save_ptr(val, writer)
+        else:
+            writer.write_int(len(self.m_Container))
+            for key, val in self.m_Container.items():
                 writer.write_aligned_string(key)
                 save_ptr(val, writer)
         return writer
+

--- a/UnityPy/classes/ResourceManager.py
+++ b/UnityPy/classes/ResourceManager.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from .Object import Object
 from .PPtr import PPtr, save_ptr
 from ..streams import EndianBinaryReader, EndianBinaryWriter
@@ -7,17 +8,17 @@ class ResourceManager(Object):
     def __init__(self, reader):
         super().__init__(reader)
         m_ContainerSize = reader.read_int()
-        self.m_Container = {
-            reader.read_aligned_string(): PPtr(reader)
-            for _ in range(m_ContainerSize)
-        }
+        self.m_Container = defaultdict(list)
+        for _ in range(m_ContainerSize):
+            self.m_Container[reader.read_aligned_string()].append(PPtr(reader))
 
     def save(self, writer: EndianBinaryWriter = None):
         if not writer:
             writer = EndianBinaryWriter(endian=self.reader.endian)
         super().save(writer, intern_call=True)
-        writer.write_int(len(self.m_Container))
-        for key, val in self.m_Container.items():
-            writer.write_aligned_string(key)
-            save_ptr(val, writer)
+        writer.write_int(sum([len(vals) for vals in self.m_Container.values()]))
+        for key, vals in self.m_Container.items():
+            for val in vals:
+                writer.write_aligned_string(key)
+                save_ptr(val, writer)
         return writer

--- a/UnityPy/classes/ResourceManager.py
+++ b/UnityPy/classes/ResourceManager.py
@@ -9,19 +9,19 @@ class ResourceManager(Object):
         super().__init__(reader)
         m_ContainerSize = reader.read_int()
         self.m_Container = {}
-        self.listContainer = defaultdict(list)
+        self.list_container = defaultdict(list)
         for _ in range(m_ContainerSize):
             key = reader.read_aligned_string()
             self.m_Container[key] = PPtr(reader)
-            self.listContainer[key].append(PPtr(reader))
+            self.list_container[key].append(PPtr(reader))
 
-    def save(self, writer: EndianBinaryWriter = None, multipleObjectsPerContainer: bool = False):
+    def save(self, writer: EndianBinaryWriter = None, multiple_objects_per_container: bool = False):
         if not writer:
             writer = EndianBinaryWriter(endian=self.reader.endian)
         super().save(writer, intern_call=True)
-        if multipleObjectsPerContainer:
-            writer.write_int(sum([len(vals) for vals in self.listContainer.values()]))
-            for key, vals in self.listContainer.items():
+        if multiple_objects_per_container:
+            writer.write_int(sum([len(vals) for vals in self.list_container.values()]))
+            for key, vals in self.list_container.items():
                 for val in vals:
                     writer.write_aligned_string(key)
                     save_ptr(val, writer)

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -179,13 +179,13 @@ class Environment:
         return search(self)
 
     @property
-    def container(self) -> Dict[str, ObjectReader]:
+    def container(self) -> Dict[str, List[ObjectReader]]:
         """Returns a dictionary of all objects in the Environment."""
         return {
-            path: obj
+            path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, obj in f.container.items()
+            for path, objs in f.container.items()
         }
 
     @property

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -179,13 +179,23 @@ class Environment:
         return search(self)
 
     @property
-    def container(self) -> Dict[str, List[ObjectReader]]:
+    def container(self) -> Dict[str, ObjectReader]:
         """Returns a dictionary of all objects in the Environment."""
+        return {
+            path: obj
+            for f in self.files.values()
+            if isinstance(f, File)
+            for path, obj in f.container.items()
+        }
+
+    @property
+    def listContainer(self) -> Dict[str, List[ObjectReader]]:
+        """Returns a dictionary of lists of all objects in the Environment."""
         return {
             path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, objs in f.container.items()
+            for path, objs in f.listContainer.items()
         }
 
     @property

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -189,13 +189,13 @@ class Environment:
         }
 
     @property
-    def listContainer(self) -> Dict[str, List[ObjectReader]]:
+    def list_container(self) -> Dict[str, List[ObjectReader]]:
         """Returns a dictionary of lists of all objects in the Environment."""
         return {
             path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, objs in f.listContainer.items()
+            for path, objs in f.list_container.items()
         }
 
     @property

--- a/UnityPy/files/File.py
+++ b/UnityPy/files/File.py
@@ -129,10 +129,10 @@ class File(object):
     @property
     def container(self):
         return {
-            path: obj
+            path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, obj in f.container.items()
+            for path, objs in f.container.items()
         }
 
     def get(self, key, default=None):

--- a/UnityPy/files/File.py
+++ b/UnityPy/files/File.py
@@ -135,12 +135,12 @@ class File(object):
             for path, obj in f.container.items()
         }
     @property
-    def listContainer(self):
+    def list_container(self):
         return {
             path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, objs in f.listContainer.items()
+            for path, objs in f.list_container.items()
         }
 
     def get(self, key, default=None):

--- a/UnityPy/files/File.py
+++ b/UnityPy/files/File.py
@@ -129,10 +129,18 @@ class File(object):
     @property
     def container(self):
         return {
+            path: obj
+            for f in self.files.values()
+            if isinstance(f, File)
+            for path, obj in f.container.items()
+        }
+    @property
+    def listContainer(self):
+        return {
             path: objs
             for f in self.files.values()
             if isinstance(f, File)
-            for path, objs in f.container.items()
+            for path, objs in f.listContainer.items()
         }
 
     def get(self, key, default=None):

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -1,4 +1,5 @@
-﻿import os
+﻿from collections import defaultdict
+import os
 import re
 
 from . import File, ObjectReader
@@ -196,7 +197,7 @@ class SerializedFile(File.File):
         self._container = {}
 
         self.objects = {}
-        self.container_ = {}
+        self.container_ = defaultdict(list)
         # used to speed up mass asset extraction
         # some assets refer to each other, so by keeping the result
         # of specific assets cached the extraction can be speed up by a lot.
@@ -277,11 +278,12 @@ class SerializedFile(File.File):
         for obj in self.objects.values():
             if obj.type == ClassIDType.AssetBundle:
                 data = obj.read()
-                for container, asset_info in data.m_Container.items():
-                    asset = asset_info.asset
-                    self.container_[container] = asset
-                    if hasattr(asset, "path_id"):
-                        self._container[asset.path_id] = container
+                for container, assets_info in data.m_Container.items():
+                    for asset_info in assets_info:
+                        asset = asset_info.asset
+                        self.container_[container].append(asset)
+                        if hasattr(asset, "path_id"):
+                            self._container[asset.path_id] = container
         # if environment is not None:
         #    environment.container = {**environment.container, **self.container}
 

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -169,7 +169,7 @@ class SerializedFile(File.File):
     _container: dict
     objects: dict
     container_: dict
-    listContainer_: dict
+    list_container_: dict
     _cache: dict
     header: SerializedFileHeader
 
@@ -199,7 +199,7 @@ class SerializedFile(File.File):
 
         self.objects = {}
         self.container_ = {}
-        self.listContainer_ = defaultdict(list)
+        self.list_container_ = defaultdict(list)
         # used to speed up mass asset extraction
         # some assets refer to each other, so by keeping the result
         # of specific assets cached the extraction can be speed up by a lot.
@@ -283,10 +283,10 @@ class SerializedFile(File.File):
                 for container, asset_info in data.m_Container.items():
                     asset = asset_info.asset
                     self.container_[container] = asset
-                for container, assets_info in data.listContainer.items():
+                for container, assets_info in data.list_container.items():
                     for asset_info in assets_info:
                         asset = asset_info.asset
-                        self.listContainer_[container].append(asset)
+                        self.list_container_[container].append(asset)
                         if hasattr(asset, "path_id"):
                             self._container[asset.path_id] = container
         # if environment is not None:
@@ -297,8 +297,8 @@ class SerializedFile(File.File):
         return self.container_
     
     @property
-    def listContainer(self):
-        return self.listContainer_
+    def list_container(self):
+        return self.list_container_
 
     def set_version(self, string_version):
         self.unity_version = string_version

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -97,7 +97,7 @@ def extract_assets(
             return 999
 
     if use_container:
-        container = sorted([(path,obj) for path, objs in env.listContainer.items() for obj in objs] if multiple_objects_per_container else env.container, key=lambda x: defaulted_export_index(x[1].type))
+        container = sorted([(path,obj) for path, objs in env.list_container.items() for obj in objs] if multiple_objects_per_container else env.container, key=lambda x: defaulted_export_index(x[1].type))
         for obj_path, obj in container:
             # the check of the various sub directories is required to avoid // in the path
             obj_dest = os.path.join(

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -69,6 +69,7 @@ def extract_assets(
     ignore_first_container_dirs: int = 0,
     append_path_id: bool = False,
     export_unknown_as_typetree: bool = False,
+    multiple_objects_per_container: bool = False,
 ) -> List[int]:
     """Extracts all assets from the given source.
 
@@ -96,7 +97,7 @@ def extract_assets(
             return 999
 
     if use_container:
-        container = sorted([(path,obj) for path, objs in env.container.items() for obj in objs],lambda x: defaulted_export_index(x[1].type))
+        container = sorted([(path,obj) for path, objs in env.listContainer.items() for obj in objs] if multiple_objects_per_container else env.container,lambda x: defaulted_export_index(x[1].type))
         for obj_path, obj in container:
             # the check of the various sub directories is required to avoid // in the path
             obj_dest = os.path.join(

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -96,7 +96,7 @@ def extract_assets(
             return 999
 
     if use_container:
-        container = sorted(env.container, lambda x: defaulted_export_index(x[1].type))
+        container = sorted([(path,obj) for path, objs in env.container.items() for obj in objs],lambda x: defaulted_export_index(x[1].type))
         for obj_path, obj in container:
             # the check of the various sub directories is required to avoid // in the path
             obj_dest = os.path.join(

--- a/examples/AssetPatch/patch.py
+++ b/examples/AssetPatch/patch.py
@@ -11,24 +11,25 @@ def main():
     src = os.path.join(root, "522608825")
     e = UnityPy.load(src)
     # iterate over all localisation assets
-    for cont, obj in e.container.items():
-        # read the asset data
-        data = obj.read()
-        # get the localisation data
-        script = json.loads(bytes(data.script)) # bytes wrapper to handle memoryview
-        if hasattr(script, "infos"):
-            continue
-        print(data.name)
-        # translate the localisation
-        for entry in script["infos"]:
-            entry["value"] = translate(entry["value"])
-        # overwrite the original
-        data.script = json.dumps(
-            script, 
-            ensure_ascii=False, indent=4
-        ).encode("utf8")
-        # apply the changes
-        data.save()
+    for cont, objs in e.container.items():
+        for obj in objs:
+            # read the asset data
+            data = obj.read()
+            # get the localisation data
+            script = json.loads(bytes(data.script)) # bytes wrapper to handle memoryview
+            if hasattr(script, "infos"):
+                continue
+            print(data.name)
+            # translate the localisation
+            for entry in script["infos"]:
+                entry["value"] = translate(entry["value"])
+            # overwrite the original
+            data.script = json.dumps(
+                script, 
+                ensure_ascii=False, indent=4
+            ).encode("utf8")
+            # apply the changes
+            data.save()
     
     # save the modified Bundle as file
     with open(os.path.join(root, "522608825_patched"), "wb") as f:

--- a/examples/AssetPatch/patch.py
+++ b/examples/AssetPatch/patch.py
@@ -11,25 +11,24 @@ def main():
     src = os.path.join(root, "522608825")
     e = UnityPy.load(src)
     # iterate over all localisation assets
-    for cont, objs in e.container.items():
-        for obj in objs:
-            # read the asset data
-            data = obj.read()
-            # get the localisation data
-            script = json.loads(bytes(data.script)) # bytes wrapper to handle memoryview
-            if hasattr(script, "infos"):
-                continue
-            print(data.name)
-            # translate the localisation
-            for entry in script["infos"]:
-                entry["value"] = translate(entry["value"])
-            # overwrite the original
-            data.script = json.dumps(
-                script, 
-                ensure_ascii=False, indent=4
-            ).encode("utf8")
-            # apply the changes
-            data.save()
+    for cont, obj in e.container.items():
+        # read the asset data
+        data = obj.read()
+        # get the localisation data
+        script = json.loads(bytes(data.script)) # bytes wrapper to handle memoryview
+        if hasattr(script, "infos"):
+            continue
+        print(data.name)
+        # translate the localisation
+        for entry in script["infos"]:
+            entry["value"] = translate(entry["value"])
+        # overwrite the original
+        data.script = json.dumps(
+            script, 
+            ensure_ascii=False, indent=4
+        ).encode("utf8")
+        # apply the changes
+        data.save()
     
     # save the modified Bundle as file
     with open(os.path.join(root, "522608825_patched"), "wb") as f:


### PR DESCRIPTION
Temporary workaround for #45 without breaking `container` compatibility before version 2

`SerializedFile`'s `_container` is also changed to be constructed using the `list_container` alternative so that all assets with a container path will properly show it instead of `None` when accessed with `.container`

A `multiple_objects_per_container` flag is introduced to `ResourceManger.save()` and `extract_assets()` in `extractor.py` to utilize `list_container` with a `False` default to avoid breaking compatibility