### PR TITLE
Fix export_func retrieval, then don't discard it

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -40,8 +40,7 @@ def export_obj(
         list: a list of exported object path_ids
     """
     # figure out export function
-    type_name = obj.type.name
-    export_func = EXPORT_TYPES[getattr(ClassIDType,type_name)]
+    export_func = EXPORT_TYPES.get(obj.type)
     if not export_func:
         if export_unknown_as_typetree:
             export_func = exportMonoBehaviour
@@ -52,7 +51,7 @@ def export_obj(
     obj = obj.read()
 
     if append_name:
-        fp = os.path.join(fp, obj.name if obj.name else type_name)
+        fp = os.path.join(fp, obj.name if obj.name else obj.type.name)
 
     fp, extension = os.path.splitext(fp)
 

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -41,11 +41,12 @@ def export_obj(
     """
     # figure out export function
     type_name = obj.type.name
-    export_func = getattr(EXPORT_TYPES, type_name)
-    if export_unknown_as_typetree:
-        export_func = exportMonoBehaviour
-    else:
-        return []
+    export_func = EXPORT_TYPES[getattr(ClassIDType,type_name)]
+    if not export_func:
+        if export_unknown_as_typetree:
+            export_func = exportMonoBehaviour
+        else:
+            return []
 
     # set filepath
     obj = obj.read()


### PR DESCRIPTION
It's unclear to me how the previous code was meant to work. `EXPORT_TYPES` is a dict, so afaik indexing is the way to get its contents, not getattr(). Could this be another change in old vs new python 3 versions?

Then the previous code threw it away, which we discussed on Discord and I fixed here.