### PR TITLE
Handle case where shader platforms and shader programs counts don't match.

### DIFF
--- a/UnityPy/export/ShaderConverter.py
+++ b/UnityPy/export/ShaderConverter.py
@@ -35,6 +35,9 @@ def ConvertSerializedShader(m_Shader):
 
     platformNumber = len(m_Shader.platforms)
     for i in range(platformNumber):
+        if i >= len(m_Shader.compressedLengths) or i >= len(m_Shader.decompressedLengths):
+            # m_Shader.platforms shouldn't be longer than m_shader.[de]compressedLengths, but it is
+            break
         compressedSize = m_Shader.compressedLengths[i]
         decompressedSize = m_Shader.decompressedLengths[i]
 
@@ -145,6 +148,10 @@ def ConvertSerializedSubPrograms(m_SubPrograms, platforms, shaderPrograms):
             subPrograms = list(_programList)
             isTier = len(subPrograms) > 1
             for i in range(len(platforms)):
+                if i >= len(shaderPrograms):
+                    # platforms shouldn't be longer than shaderPrograms, but it is
+                    break
+
                 platform = platforms[i]
 
                 if CheckGpuProgramUsable(platform, programKey):


### PR DESCRIPTION
While extracting assets from the game "As Far As The Eye" I encountered some tuple and list index errors due to a shader having two platforms but just one program. This patch bails on the relevant loops when the lengths/programs are exhausted. There may be more appropriate behavior, such as serializing the same program for both platforms?

Here is a little bit of debug output I printed while troubleshooting this, for the problematic shader:
```
m_Shader.platforms is [<ShaderCompilerPlatform.kShaderCompPlatformOpenGLCore: 15>, <ShaderCompilerPlatform.kShaderCompPlatformVulkan: 18>]
m_shader.compressedLengths is (896,)
m_shader.decompressedLengths is (2504,)
shaderPrograms is [<UnityPy.export.ShaderConverter.ShaderProgram object at 0x7f3d2929dff0>]
```