### PR TITLE
Handle exportMonoBehavior for Object without serialized type or nodes

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -187,6 +187,7 @@ def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
 def exportMonoBehaviour(
     obj: Union[MonoBehaviour, Object], fp: str, extension: str = ""
 ) -> List[int]:
+    export = None
     # TODO - add generic way to add external typetrees
     if obj.serialized_type and obj.serialized_type.nodes:
         extension = ".json"


### PR DESCRIPTION
While exporting assets from the game "As Far As The Eye" I encountered a call to exportMonoBehaviour for an Object (not a MonoBehaviour), when the Object failed the `if obj.serialized_type and obj.serialized_type.nodes:` test. This led to:

```
  File "/home/sparr/.local/share/virtualenvs/vgm-extractor-1oHW3IDG/src/unitypy/UnityPy/tools/extractor.py", line 219, in exportMonoBehaviour
    if not export:
UnboundLocalError: local variable 'export' referenced before assignment
```

So I've initialized it here to avoid this error.