### PR TITLE
Pass asset_filter from extract_assets to export_obj

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -122,6 +122,7 @@ def extract_assets(
                     obj_dest,
                     append_path_id=append_path_id,
                     export_unknown_as_typetree=export_unknown_as_typetree,
+                    asset_filter=asset_filter,
                 )
             )
 
@@ -138,6 +139,7 @@ def extract_assets(
                         append_name=True,
                         append_path_id=append_path_id,
                         export_unknown_as_typetree=export_unknown_as_typetree,
+                        asset_filter=asset_filter,
                     )
                 )
 


### PR DESCRIPTION
I failed to include this in #133. asset_filter needs to be passed from `export_assets` to `export_obj` so that it can be run a second time after `obj.read()` is performed.