### PR TITLE
Disambiguate path_id collision using obj type. Change extract/export return type.

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -130,7 +130,7 @@ def extract_assets(
         for obj in objects:
             if asset_filter is not None and not asset_filter(obj):
                 continue
-            if obj.path_id not in exported:
+            if (obj.type, obj.path_id) not in exported:
                 exported.extend(
                     export_obj(
                         obj,
@@ -154,7 +154,7 @@ def exportTextAsset(obj: TextAsset, fp: str, extension: str = ".txt") -> List[in
         extension = ".txt"
     with open(f"{fp}{extension}", "wb") as f:
         f.write(obj.script)
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportFont(obj: Font, fp: str, extension: str = "") -> List[int]:
@@ -165,7 +165,7 @@ def exportFont(obj: Font, fp: str, extension: str = "") -> List[int]:
             extension = ".otf"
         with open(f"{fp}{extension}", "wb") as f:
             f.write(obj.m_FontData)
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportMesh(obj: Mesh, fp: str, extension=".obj") -> List[int]:
@@ -173,7 +173,7 @@ def exportMesh(obj: Mesh, fp: str, extension=".obj") -> List[int]:
         extension = ".obj"
     with open(f"{fp}{extension}", "wt", encoding="utf8", newline="") as f:
         f.write(obj.export())
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
@@ -181,7 +181,7 @@ def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
         extension = ".txt"
     with open(f"{fp}{extension}", "wt", encoding="utf8", newline="") as f:
         f.write(obj.export())
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportMonoBehaviour(
@@ -221,7 +221,7 @@ def exportMonoBehaviour(
         export = obj.raw_data
     with open(f"{fp}{extension}", "wb") as f:
         f.write(export)
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportAudioClip(obj: AudioClip, fp: str, extension: str = "") -> List[int]:
@@ -236,18 +236,22 @@ def exportAudioClip(obj: AudioClip, fp: str, extension: str = "") -> List[int]:
         for name, clip_data in samples.items():
             with open(os.path.join(fp, f"{name}.wav"), "wb") as f:
                 f.write(clip_data)
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportSprite(obj: Sprite, fp: str, extension: str = ".png") -> List[int]:
     if not extension:
         extension = ".png"
     obj.image.save(f"{fp}{extension}")
-    return [
-        obj.path_id,
-        obj.m_RD.texture.path_id,
-        getattr(obj.m_RD.alphaTexture, "path_id", None),
+    exported = [
+        (obj.type, obj.path_id),
+        (obj.m_RD.texture.type, obj.m_RD.texture.path_id),
     ]
+    alpha_path_id = getattr(obj.m_RD.alphaTexture, "path_id", None)
+    alpha_type = getattr(obj.m_RD.alphaTexture, "type", None)
+    if alpha_path_id and alpha_type:
+        exported.append((alpha_type, alpha_path_id))
+    return exported
 
 
 def exportTexture2D(obj: Texture2D, fp: str, extension: str = ".png") -> List[int]:
@@ -256,11 +260,11 @@ def exportTexture2D(obj: Texture2D, fp: str, extension: str = ".png") -> List[in
     if obj.m_Width:
         # textures can be empty
         obj.image.save(f"{fp}{extension}")
-    return [obj.path_id]
+    return [(obj.type, obj.path_id)]
 
 
 def exportGameObject(obj: GameObject, fp: str, extension: str = "") -> List[int]:
-    exported = [obj.path_id]
+    exported = [(obj.type, obj.path_id)]
     refs = crawl_obj(obj)
     if refs:
         os.makedirs(fp, exist_ok=True)
@@ -268,7 +272,7 @@ def exportGameObject(obj: GameObject, fp: str, extension: str = "") -> List[int]
         # Don't export already exported objects a second time
         # and prevent circular calls by excluding other GameObjects.
         # The other GameObjects were already exported in the this call.
-        if ref_id in exported or ref_id.type == ClassIDType.GameObject:
+        if (ref.type, ref_id) in exported or ref.type == ClassIDType.GameObject:
             continue
         try:
             exported.extend(export_obj(ref, fp, True, True))

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -131,7 +131,7 @@ def extract_assets(
         for obj in objects:
             if asset_filter is not None and not asset_filter(obj):
                 continue
-            if (obj.type, obj.path_id) not in exported:
+            if (obj.assets_file, obj.path_id) not in exported:
                 exported.extend(
                     export_obj(
                         obj,
@@ -156,7 +156,7 @@ def exportTextAsset(obj: TextAsset, fp: str, extension: str = ".txt") -> List[in
         extension = ".txt"
     with open(f"{fp}{extension}", "wb") as f:
         f.write(obj.script)
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportFont(obj: Font, fp: str, extension: str = "") -> List[int]:
@@ -167,7 +167,7 @@ def exportFont(obj: Font, fp: str, extension: str = "") -> List[int]:
             extension = ".otf"
         with open(f"{fp}{extension}", "wb") as f:
             f.write(obj.m_FontData)
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportMesh(obj: Mesh, fp: str, extension=".obj") -> List[int]:
@@ -175,7 +175,7 @@ def exportMesh(obj: Mesh, fp: str, extension=".obj") -> List[int]:
         extension = ".obj"
     with open(f"{fp}{extension}", "wt", encoding="utf8", newline="") as f:
         f.write(obj.export())
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
@@ -183,7 +183,7 @@ def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
         extension = ".txt"
     with open(f"{fp}{extension}", "wt", encoding="utf8", newline="") as f:
         f.write(obj.export())
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportMonoBehaviour(
@@ -224,7 +224,7 @@ def exportMonoBehaviour(
         export = obj.raw_data
     with open(f"{fp}{extension}", "wb") as f:
         f.write(export)
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportAudioClip(obj: AudioClip, fp: str, extension: str = "") -> List[int]:
@@ -239,7 +239,7 @@ def exportAudioClip(obj: AudioClip, fp: str, extension: str = "") -> List[int]:
         for name, clip_data in samples.items():
             with open(os.path.join(fp, f"{name}.wav"), "wb") as f:
                 f.write(clip_data)
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportSprite(obj: Sprite, fp: str, extension: str = ".png") -> List[int]:
@@ -247,13 +247,13 @@ def exportSprite(obj: Sprite, fp: str, extension: str = ".png") -> List[int]:
         extension = ".png"
     obj.image.save(f"{fp}{extension}")
     exported = [
-        (obj.type, obj.path_id),
-        (obj.m_RD.texture.type, obj.m_RD.texture.path_id),
+        (obj.assets_file, obj.path_id),
+        (obj.m_RD.texture.assets_file, obj.m_RD.texture.path_id),
     ]
+    alpha_assets_file = getattr(obj.m_RD.alphaTexture, "assets_file", None)
     alpha_path_id = getattr(obj.m_RD.alphaTexture, "path_id", None)
-    alpha_type = getattr(obj.m_RD.alphaTexture, "type", None)
-    if alpha_path_id and alpha_type:
-        exported.append((alpha_type, alpha_path_id))
+    if alpha_path_id and alpha_assets_file:
+        exported.append((alpha_assets_file, alpha_path_id))
     return exported
 
 
@@ -263,11 +263,11 @@ def exportTexture2D(obj: Texture2D, fp: str, extension: str = ".png") -> List[in
     if obj.m_Width:
         # textures can be empty
         obj.image.save(f"{fp}{extension}")
-    return [(obj.type, obj.path_id)]
+    return [(obj.assets_file, obj.path_id)]
 
 
 def exportGameObject(obj: GameObject, fp: str, extension: str = "") -> List[int]:
-    exported = [(obj.type, obj.path_id)]
+    exported = [(obj.assets_file, obj.path_id)]
     refs = crawl_obj(obj)
     if refs:
         os.makedirs(fp, exist_ok=True)
@@ -275,7 +275,7 @@ def exportGameObject(obj: GameObject, fp: str, extension: str = "") -> List[int]
         # Don't export already exported objects a second time
         # and prevent circular calls by excluding other GameObjects.
         # The other GameObjects were already exported in the this call.
-        if (ref.type, ref_id) in exported or ref.type == ClassIDType.GameObject:
+        if (ref.assets_file, ref_id) in exported or ref.type == ClassIDType.GameObject:
             continue
         try:
             exported.extend(export_obj(ref, fp, True, True))

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -122,6 +122,7 @@ def extract_assets(
                     obj_dest,
                     append_path_id=append_path_id,
                     export_unknown_as_typetree=export_unknown_as_typetree,
+                    asset_filter=asset_filter,
                 )
             )
 
@@ -138,6 +139,7 @@ def extract_assets(
                         append_name=True,
                         append_path_id=append_path_id,
                         export_unknown_as_typetree=export_unknown_as_typetree,
+                        asset_filter=asset_filter,
                     )
                 )
 

--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -189,6 +189,7 @@ def exporShader(obj: Shader, fp: str, extension=".txt") -> List[int]:
 def exportMonoBehaviour(
     obj: Union[MonoBehaviour, Object], fp: str, extension: str = ""
 ) -> List[int]:
+    export = None
     # TODO - add generic way to add external typetrees
     if obj.serialized_type and obj.serialized_type.nodes:
         extension = ".json"


### PR DESCRIPTION
When multiple assets have the same `path_id` and `use_container` is `False` then only the first such asset will be exported. This patch stores a tuple of `(obj.type, obj.path_id)` instead of just `obj.path_id` to disambiguate and allow all the assets to pass the check.

This patch changes the return type of `extract_assets`, `export_obj`, and all of the type-specific export functions. Instead of returning `list[int]` they now return `list[tuple[ClassIDType, int]]`. This is a breaking change, although I cannot find any current uses of extract_assets or export_obj on github that would be broken.

It would be possible to `return [path_id for _,path_id in exported]` to avoid the breaking change, but that would continue the current state of producing an ambiguous list of path_ids that can't be resolved back to specific assets.

I do not (that I know of) have an assets file with which to test some of the code here, specifically the Sprite.m_RD.alphaTexture logic.