### PR TITLE
Renamed linux wheels with proper platform tags

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -78,7 +78,9 @@ jobs:
                     ${{ matrix.cp }}-macosx_x86_64
                     ${{ matrix.cp }}-macosx_arm64
                     ${{ matrix.cp }}-macosx_universal2
-                  CIBW_REPAIR_WHEEL_COMMAND: "" # Disable auditwheel
+                  # Disabled repair wheel since the fmob lib is not compatible
+                  CIBW_REPAIR_WHEEL_COMMAND: ""
+                  CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'mv {wheel} {dest_dir}/"$(basename {wheel} | sed "s/-linux_/-manylinux_2_17_/")"'
                   CIBW_TEST_REQUIRES: pytest
                   CIBW_TEST_COMMAND: pytest -v -s {package}/tests
                   CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"


### PR DESCRIPTION
Normally auditwheel will rename the wheels on linux. Since we don't use auditwheel, we would need to rename the files ourselves.

This is pretty fragile since build output can change in the future. Hopefully by pinning cibuildwheel to the exact version, it doesn't change too much.