### PR TITLE
BundleFile: fix exception on file.save("original")

### DIFF
--- a/UnityPy/files/BundleFile.py
+++ b/UnityPy/files/BundleFile.py
@@ -223,7 +223,7 @@ class BundleFile(File.File):
             elif packer == "original":
                 self.save_fs(
                     writer,
-                    data_flag=self._data_flags,
+                    data_flag=self.dataflags,
                     block_info_flag=self._block_info_flags,
                 )
             elif packer == "lz4":


### PR DESCRIPTION
Regression in commit https://github.com/K0lb3/UnityPy/commit/9232cdd57e93f140b2d7431905baff40e05488bc (release 1.9.21), which renamed `_data_flags` to `dataflags`.