### PR TITLE
AttributeError: 'EndianBinaryReader_Memoryview_BigEndian' object has no attribute 'is_changed'

### DIFF
--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -153,7 +153,7 @@ class Environment:
         pack = "none" (default) or "lz4"
         """
         for f in self.files:
-            if self.files[f].is_changed:
+             if hasattr(self.files[f], 'is_changed') and self.files[f].is_changed:
                 with open(
                     os.path.join(self.out_path, os.path.basename(f)), "wb"
                 ) as out:

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -155,9 +155,9 @@ class Environment:
         for fname, fitem in self.files.items():
             if getattr(fitem, "is_changed", False):
                 with open(
-                    os.path.join(self.out_path, os.path.basename(f)), "wb"
+                    os.path.join(self.out_path, os.path.basename(fname)), "wb"
                 ) as out:
-                    out.write(self.files[f].save(packer=pack))
+                    out.write(fitem.save(packer=pack))
 
     @property
     def objects(self) -> List[ObjectReader]:

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -152,8 +152,8 @@ class Environment:
         Mark assets as changed using `.mark_changed()`.
         pack = "none" (default) or "lz4"
         """
-        for f in self.files:
-             if hasattr(self.files[f], 'is_changed') and self.files[f].is_changed:
+        for fname, fitem in self.files.items():
+            if getattr(fitem, "is_changed", False):
                 with open(
                     os.path.join(self.out_path, os.path.basename(f)), "wb"
                 ) as out:


### PR DESCRIPTION
Fixed a bug where Enviroment.save() function was always assuming all asset objects have the "is_changed" attributes, causing it to raise an exception if it encountered an "EndianBinaryReader_Memoryview_BigEndian" object, as that object doesn't have an "is_changed" attribute.