### PR TITLE
Fix ContainerHelper from being non-iterable

### DIFF
--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -673,7 +673,7 @@ class ContainerHelper:
         raise NotImplementedError("Deleting from the container is not allowed!")
 
     def __iter__(self):
-        return iter(self.keys)
+        return iter(self.keys())
 
     def __len__(self):
         return len(self.container)


### PR DESCRIPTION
It's a very simple fix, one line and probably a simple mistake, but this single line caused my whole project to break when I updated the UnityPy version haha