### PR TITLE
Fix random ResourceReader file loading

### DIFF
--- a/UnityPy/helpers/ResourceReader.py
+++ b/UnityPy/helpers/ResourceReader.py
@@ -22,12 +22,12 @@ def get_resource_data(*args):
         res_path, assets_file, offset, size = args
         basename = ntpath.basename(res_path)
         name, ext = ntpath.splitext(basename)
-        possible_names = {
+        possible_names = [
             basename,
             f"{name}.resource",
             f"{name}.assets.resS",
             f"{name}.resS",
-        }
+        ]
         environment = assets_file.environment
         reader = None
         for possible_name in possible_names:


### PR DESCRIPTION
You may not believe it (or you probably did already), but `possible_names` was actually a dictionary type before. The problem with that is you get these random numbers as keys, and the items inside go out of order.

![image](https://github.com/K0lb3/UnityPy/assets/57239451/556bbef2-272e-4329-ae5a-4f320f3bdb7c)
