### PR TITLE
Handle relative and case insensitive file paths

### DIFF
--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -112,7 +112,7 @@ class Environment:
                     file = os.path.join(self.path, file)
                 # Unity paths are case insensitive, so we need to find "Resources/Foo.asset" when the record says "resources/foo.asset"
                 if not os.path.exists(file):
-                    file = ImportHelper.find_sensitive_path("/", file)
+                    file = ImportHelper.find_sensitive_path(self.path, file)
                 # nonexistent files might be packaging errors or references to Unity's global Library/
                 if file is None:
                     return

--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -107,15 +107,16 @@ class Environment:
                 file = b"".join(file)
             else:
                 name = file
-                # relative paths are in the asset directory, not the cwd
-                if not os.path.isabs(file):
-                    file = os.path.join(self.path, file)
-                # Unity paths are case insensitive, so we need to find "Resources/Foo.asset" when the record says "resources/foo.asset"
                 if not os.path.exists(file):
-                    file = ImportHelper.find_sensitive_path(self.path, file)
-                # nonexistent files might be packaging errors or references to Unity's global Library/
-                if file is None:
-                    return
+                    # relative paths are in the asset directory, not the cwd
+                    if not os.path.isabs(file):
+                        file = os.path.join(self.path, file)
+                    # Unity paths are case insensitive, so we need to find "Resources/Foo.asset" when the record says "resources/foo.asset"
+                    if not os.path.exists(file):
+                        file = ImportHelper.find_sensitive_path(self.path, file)
+                    # nonexistent files might be packaging errors or references to Unity's global Library/
+                    if file is None:
+                        return
                 file = self.fs.open(file, "rb")
 
         typ, reader = ImportHelper.check_file_type(file)

--- a/UnityPy/helpers/ImportHelper.py
+++ b/UnityPy/helpers/ImportHelper.py
@@ -1,4 +1,5 @@
-﻿import os
+from __future__ import annotations
+import os
 from typing import Union, List
 from .CompressionHelper import BROTLI_MAGIC, GZIP_MAGIC
 from ..enums import FileType
@@ -150,11 +151,7 @@ def find_sensitive_path(dir: str, insensitive_path: str) -> Union[str, None]:
     for part in parts:
         part_lower = part.lower()
         part = next(
-            (
-                name
-                for name in os.listdir(senstive_path)
-                if name.lower() == part_lower
-            ),
+            (name for name in os.listdir(senstive_path) if name.lower() == part_lower),
             None,
         )
         if next is None:

--- a/UnityPy/helpers/ImportHelper.py
+++ b/UnityPy/helpers/ImportHelper.py
@@ -141,3 +141,20 @@ def parse_file(
     else:
         f = reader
     return f
+
+## finds the case sensitive path to a file described by a case insensitive path
+# https://stackoverflow.com/a/37708342/13675
+def find_sensitive_path(dir, insensitive_path):
+
+    insensitive_path = insensitive_path.strip(os.path.sep)
+
+    parts = insensitive_path.split(os.path.sep)
+    next_name = parts[0]
+    for name in os.listdir(dir):
+        if next_name.lower() == name.lower():
+            improved_path = os.path.join(dir, name)
+            if len(parts) == 1:
+                return improved_path
+            else:
+                return find_sensitive_path(improved_path, os.path.sep.join(parts[1:]))
+    return None

--- a/UnityPy/helpers/ImportHelper.py
+++ b/UnityPy/helpers/ImportHelper.py
@@ -127,7 +127,7 @@ def parse_file(
     name: str,
     typ: FileType = None,
     is_dependency=False,
-):
+) -> Union[files.File, EndianBinaryReader]:
     if typ is None:
         typ, _ = check_file_type(reader)
     if typ == FileType.AssetsFile and not name.endswith(
@@ -142,19 +142,23 @@ def parse_file(
         f = reader
     return f
 
-## finds the case sensitive path to a file described by a case insensitive path
-# https://stackoverflow.com/a/37708342/13675
-def find_sensitive_path(dir, insensitive_path):
 
-    insensitive_path = insensitive_path.strip(os.path.sep)
+def find_sensitive_path(dir: str, insensitive_path: str) -> Union[str, None]:
+    parts = os.path.split(insensitive_path.strip(os.path.sep))
 
-    parts = insensitive_path.split(os.path.sep)
-    next_name = parts[0]
-    for name in os.listdir(dir):
-        if next_name.lower() == name.lower():
-            improved_path = os.path.join(dir, name)
-            if len(parts) == 1:
-                return improved_path
-            else:
-                return find_sensitive_path(improved_path, os.path.sep.join(parts[1:]))
-    return None
+    senstive_path = dir
+    for part in parts:
+        part_lower = part.lower()
+        part = next(
+            (
+                name
+                for name in os.listdir(senstive_path)
+                if name.lower() == part_lower
+            ),
+            None,
+        )
+        if next is None:
+            return None
+        senstive_path = os.path.join(senstive_path, part)
+
+    return senstive_path


### PR DESCRIPTION
This PR resolves a few problems I had exporting assets from the game Autonauts.

1. One assets file contains a reference to another with a relative path, which UnityPy was trying to load from the script's CWD instead of the original asset file path.
2. That reference doesn't match the case of the actual directory or file name.
3. There is another reference to `library/unity default assets` which, in addition to being relative and case insensitive, also doesn't exist because `Library/` is apparently a magic path in Unity. Rather than calling that out explicitly here, I've opted to just silently ignore nonexistent paths/files.

I wasn't able to test on Windows, which might have a problem with the case insensitive search.

PS: I also spotted a bug in `save()` but can't test the fix I included here. Let me know if that's a problem and I can remove it.