### PR TITLE
Fix ContainerHelper for .container retrieval

### DIFF
--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -139,11 +139,7 @@ class ObjectReader:
 
     @property
     def container(self):
-        return (
-            self.assets_file._container[self.path_id]
-            if self.path_id in self.assets_file._container
-            else None
-        )
+        return self.assets_file._container.path_dict.get(self.path_id)
 
     @property
     def Position(self):

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -653,7 +653,7 @@ class ContainerHelper:
         self.container = container
         # support for getitem
         self.container_dict = {key: value.asset for key, value in container}
-        self.path_dict = {value.asset.path_id: value.asset for key, value in container}
+        self.path_dict = {value.asset.path_id: key for key, value in container}
 
     def items(self):
         return ((key, value.asset) for key, value in self.container)


### PR DESCRIPTION
This commit is aware of the difference between `_container` and `container_` in old versions of SerializedFile.py for compatibility.

It should be matching the behavior of .container property in the previous versions, addressing the issue #199 in 1.10.2 returning None for the first two items below:
- .container in ObjectReader.py: returning the container path of the asset the ObjectReader handles.
- .container in Object.py: same as above.
- .container in SerializedFile.py: returning the {container path: a corresponding asset} dictionary now handled by ContainerHelper (the legacy `container_` attribute)

Resolves #199