### PR TITLE
Fixing the reversed flip operation for packed sprite

### DIFF
--- a/UnityPy/export/SpriteHelper.py
+++ b/UnityPy/export/SpriteHelper.py
@@ -66,10 +66,10 @@ def get_image_from_sprite(m_Sprite) -> Image.Image:
     if settings_raw.packed == 1:
         rotation = settings_raw.packingRotation
         if rotation == SpritePackingRotation.kSPRFlipHorizontal:
-            sprite_image = sprite_image.transpose(Image.FLIP_TOP_BOTTOM)
+            sprite_image = sprite_image.transpose(Image.FLIP_LEFT_RIGHT)
         # spriteImage = RotateFlip(RotateFlipType.RotateNoneFlipX)
         elif rotation == SpritePackingRotation.kSPRFlipVertical:
-            sprite_image = sprite_image.transpose(Image.FLIP_LEFT_RIGHT)
+            sprite_image = sprite_image.transpose(Image.FLIP_TOP_BOTTOM)
         # spriteImage.RotateFlip(RotateFlipType.RotateNoneFlipY)
         elif rotation == SpritePackingRotation.kSPRRotate180:
             sprite_image = sprite_image.transpose(Image.ROTATE_180)


### PR DESCRIPTION
Fixing the flip transpose operation when extracting a packed sprite image from a texture.
This addresses issue #206.