### PR TITLE
Fixed "Exception: String not terminated".

### DIFF
--- a/UnityPy/environment.py
+++ b/UnityPy/environment.py
@@ -274,7 +274,7 @@ class Environment:
                 data = b"".join(data)
                 path = basepath
             else:
-                data = open_f(path).read()
+                data = open_f(path)
             self.load_file(data, name=path)
 
     def find_file(self, name: str, is_dependency: bool = True) -> Union[File, None]:


### PR DESCRIPTION
Fixed a bug that caused using Environment.load() on a folder that contains plain text file independent of it's extension, to cause an "Exception: String not terminated".