### PR TITLE
fix: TypeError: 'ABCMeta' object is not subscriptable

### DIFF
--- a/UnityPy/tools/extractor.py
+++ b/UnityPy/tools/extractor.py
@@ -16,9 +16,8 @@ from UnityPy.classes import (
     GameObject,
 )
 from UnityPy.enums.ClassIDType import ClassIDType
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Callable
 from pathlib import Path
-from collections.abc import Callable
 
 
 def export_obj(


### PR DESCRIPTION
collections.abc.Callable cannot be used for type hints when python<3.9