### PR TITLE
Fix Unity 2022.1 Support

### DIFF
--- a/UnityPy/classes/AnimationClip.py
+++ b/UnityPy/classes/AnimationClip.py
@@ -519,6 +519,8 @@ class GenericBinding:
             self.typeID = ClassIDType(reader.read_u_short())
         self.customType = reader.read_byte()
         self.isPPtrCurve = reader.read_byte()
+        if version >= (2022, 1):  # 2022.1 and up
+            self.isIntCurve = reader.read_byte()        
         reader.align_stream()
 
 

--- a/UnityPy/classes/Mesh.py
+++ b/UnityPy/classes/Mesh.py
@@ -494,6 +494,10 @@ class Mesh(NamedObject):
             m_CollisionVertexCount = reader.read_int()
 
         self.m_MeshUsageFlags = reader.read_int()
+
+        if version >= (2022, 1):  # 2022.1 and up
+            self.m_CookingOptions = reader.read_int()
+        
         if version >= (5,):  # 5.0 and up
             self.m_BakedConvexCollisionMesh = reader.read_bytes(reader.read_int())
             reader.align_stream()


### PR DESCRIPTION
[AssetStudio introduced its Unity 2022.1 update in its last commit](https://github.com/Perfare/AssetStudio/commit/d158e864b556b5970709c2a52e47944d53aa98a2), which isn't thoroughly implemented here.
This PR adds these new properties. Which addresses https://github.com/mos9527/sssekai_blender_io/issues/3