### PR TITLE
Fix LZMA decompression

### DIFF
--- a/UnityPy/helpers/CompressionHelper.py
+++ b/UnityPy/helpers/CompressionHelper.py
@@ -36,7 +36,7 @@ def decompress_lzma(data: bytes) -> bytes:
             }
         ],
     )
-    return dec.decompress(data[5:])
+    return dec.decompress(data[13:])
 
 
 def compress_lzma(data: bytes) -> bytes:


### PR DESCRIPTION
In Unity LZMA file, headers [5:13] is decompressed size, should be skipped.
This PR solves the decompression issue #237 
