### PR TITLE
Fix SerializedType dependency count on write

### DIFF
--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -166,7 +166,7 @@ class SerializedType:
                     writer.write_string_to_null(self.m_NameSpace)
                     writer.write_string_to_null(self.m_AssemblyName)
                 else:
-                    writer.write_int_array(self.type_dependencies)
+                    writer.write_int_array(self.type_dependencies, write_length=True)
 
 
 class SerializedFile(File.File):
@@ -630,9 +630,6 @@ class SerializedFile(File.File):
 
         # string buffer
         writer.write(string_buffer.bytes)
-
-        if self.header.version >= 21:
-            writer.write_bytes(b"\x00" * 4)
 
 
 def read_string(string_buffer_reader: EndianBinaryReader, value: int) -> str:


### PR DESCRIPTION
When reading the types from a version 21+ asset, UnityPy correctly [reads the type tree](https://github.com/mmatyas/UnityPy/blob/df73acbd416bde000e3b30fa548349bcc38bce3b/UnityPy/files/SerializedFile.py#L126), then correctly [reads the list of dependencies](https://github.com/mmatyas/UnityPy/blob/df73acbd416bde000e3b30fa548349bcc38bce3b/UnityPy/files/SerializedFile.py#L136) as a regular "count + elements" array.

However, when writing the type tree, UnityPy [writes a fixed 0x0](https://github.com/mmatyas/UnityPy/blob/df73acbd416bde000e3b30fa548349bcc38bce3b/UnityPy/files/SerializedFile.py#L635) in place of the dependency array length, then [writes the array without a count field](https://github.com/mmatyas/UnityPy/blob/df73acbd416bde000e3b30fa548349bcc38bce3b/UnityPy/files/SerializedFile.py#L169) (with `write_length` being `False` by default). This results a corrupted file when a type actually has dependencies.