### PR TITLE
SerializedType - fix `attrs` accidentally removing default class attributes

### DIFF
--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -106,7 +106,7 @@ class BuildType:
         return self.build_type == "p"
 
 
-@define(slots=True)
+@define(slots=True, init=False)
 class SerializedType:
     class_id: int
     is_stripped_type: Optional[bool] = None
@@ -129,6 +129,7 @@ class SerializedType:
     ):
         version = serialized_file.header.version
         self.class_id = reader.read_int()
+        self.__attrs_init__(self.class_id)
 
         if version >= 16:
             self.is_stripped_type = reader.read_boolean()


### PR DESCRIPTION
When a bundle file doesn't contain its typetree (i.e. `SerializedFile._enable_type_tree` is `False`), [the `node` attribute in `SerializedType` will never be written.](https://github.com/K0lb3/UnityPy/blob/ee8643e5bac90306a5ab933b899f2d371dddf507/UnityPy/files/SerializedFile.py#L148) 
Which would crash UnityPy.

This behavior is identical with previous versions of UnityPy as the default (`None`) would be used.
However, since `attrs.define` is used whlist having a custom `__init__` method on the class - these attributes will be removed unless written otherwise.

This crashes the `ObjectReader` as [the node attribute is always expected to be present.](https://github.com/K0lb3/UnityPy/blob/ee8643e5bac90306a5ab933b899f2d371dddf507/UnityPy/files/ObjectReader.py#L252)

---

The patch invokes `__attrs_init__` in `SerializedType`'s cutsom init function (as per [the docs](https://www.attrs.org/en/stable/init.html#hooking-yourself-into-initialization)) so that the default values are correctly preserved. Removing the decorator would also fix this issue.

BTW it seems like most of the classes have custom init while being decorated by `@define` too in [SerializedFile.py](https://github.com/K0lb3/UnityPy/blob/ee8643e5bac90306a5ab933b899f2d371dddf507/UnityPy/files/SerializedFile.py). Is having the decorators there in the first place necessary at all?

---

The attached bundle file would reproduce the issue by simply reading all the objects as of commit [6350e2ec327334c8a9b7f494f344a761.](https://github.com/K0lb3/UnityPy/commit/8fcc664d1f5d24d8d5ab8b96e3db50728c0a8bb1)

[6350e2ec327334c8a9b7f494f344a761.zip](https://github.com/user-attachments/files/17230799/6350e2ec327334c8a9b7f494f344a761.zip)

```python
In [1]: import UnityPy

In [2]: env = UnityPy.load('6350e2ec327334c8a9b7f494f344a761')

In [3]: for obj in env.objects: obj.read()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 for obj in env.objects: obj.read()

File ~\UnityPy\UnityPy\files\ObjectReader.py:174, in ObjectReader.read(self)
    173 def read(self) -> T:
--> 174     obj = self.read_typetree(wrap=True)
    175     self._read_until = self.reader.Position
    176     return obj

File ~\UnityPy\UnityPy\files\ObjectReader.py:208, in ObjectReader.read_typetree(self, nodes, wrap)
    202 def read_typetree(
    203     self,
    204     nodes: Optional[Union[TypeTreeNode, List[dict]]] = None,
    205     wrap: bool = False,
    206 ) -> Union[dict, T]:
    207     self.reset()
--> 208     node = self._get_typetree_node(nodes)
    209     ret = TypeTreeHelper.read_typetree(
    210         node,
    211         self.reader,
   (...)
    214         expected_read=self.byte_size,
    215     )
    216     if wrap:

File ~\UnityPy\UnityPy\files\ObjectReader.py:252, in ObjectReader._get_typetree_node(self, node)
    249     raise ValueError("nodes must be a list[dict] or TypeTreeNode")
    251 if self.serialized_type:
--> 252     node = self.serialized_type.node
    253 if not node:
    254     node = get_typetree_node(self.class_id, self.version)

AttributeError: 'SerializedType' object has no attribute 'node'
```
