### PR TITLE
Improve efficiency and fix concurrent issue of audio dumping

### DIFF
--- a/UnityPy/export/AudioClipConverter.py
+++ b/UnityPy/export/AudioClipConverter.py
@@ -4,7 +4,7 @@ import ctypes
 import os
 import platform
 from threading import Lock
-from typing import TYPE_CHECKING, Dict, Union
+from typing import TYPE_CHECKING, Dict
 
 from UnityPy.streams import EndianBinaryWriter
 
@@ -28,15 +28,14 @@ pyfmodex = None
 
 
 def get_fmod_path(
-    system: Union["Windows", "Linux", "Darwin"], arch: ["x64", "x86", "arm", "arm64"]
+    system: str,  # "Windows", "Linux", "Darwin"
+    arch: str,  # "x64", "x86", "arm", "arm64"
 ) -> str:
     if system == "Darwin":
         # universal dylib
         return "lib/FMOD/Darwin/libfmod.dylib"
-
     if system == "Windows":
         return f"lib/FMOD/Windows/{arch}/fmod.dll"
-
     if system == "Linux":
         if arch == "x64":
             arch = "x86_64"
@@ -127,6 +126,7 @@ def get_pyfmodex_system_instance(channels: int, flags: int):
         lock = Lock()
         SYSTEM_INSTANCES[instance_key] = (system, lock)
         return system, lock
+
 
 def dump_samples(
     clip: AudioClip, audio_data: bytes, convert_pcm_float: bool = True


### PR DESCRIPTION
## Summary

First, this PR modified `AudioClipConverter.py`, adding **a reuse strategy for `pyfmodex.System` instance** to improve the efficiency of `dump_samples()` method. In the best case, this improvement lead to 5x more efficiency.

Second, a `threading.Lock` was added in order to protect the `pyfmodex.System` to avoid **concurrent issue**.

## Part 1. Efficiency Improvement

Before the improvement was introduced, we investigated the time consumption distribution in `dump_samples()` method. The following time-tests results are based on audio clips whose duration ranging from 1s to 20s.

1. System instance initialization **(64%)**
  ```python
  system = pyfmodex.System()
  system.init(clip.m_Channels, pyfmodex.flags.INIT_FLAGS.NORMAL, None)
  ```
2. Sound creation and transformation **(11%)**
  ```python
  sound = system.create_sound(
      bytes(audio_data),
      pyfmodex.flags.MODE.OPENMEMORY,
      exinfo=pyfmodex.structure_declarations.CREATESOUNDEXINFO(
          length=len(audio_data),
          numchannels=clip.m_Channels,
          defaultfrequency=clip.m_Frequency,
      ),
  )
  
  # iterate over subsounds
  samples = {}
  for i in range(sound.num_subsounds):
      if i > 0:
          filename = "%s-%i.wav" % (clip.m_Name, i)
      else:
          filename = "%s.wav" % clip.m_Name
      subsound = sound.get_subsound(i)
      samples[filename] = subsound_to_wav(subsound, convert_pcm_float)
      subsound.release()
  ```
3. Resource release **(25%)**
  ```python
  sound.release()
  system.release()
  ```

As you can see, the system initialization and release takes the 89% time of the audio dumping. It is important to see that we need to re-init a system **only if** the `clip.m_Channels` changed. So we can use a **reuse trick** to avoid meaningless initializations.

In the best case where all clips have the same num_channels, we can get 5x more efficiency because the system only needs to be inited **once**.

## Part 2. Concurrent Issue Fix

When we use **multithreading** to dump audio files, an `FmodError: MEMORY` will be raise at `pyfmodex.System()` the creation method. This is not caused by insufficient memory but **asynchronous access** to the pyfmodex.

To fix this problem, we introduce a threading lock to prevent the asynchronous access. This approach will hardly affect performance.