### PR TITLE
Fix concurrent issue of ASTC context

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -71,24 +71,24 @@ def image_to_texture2d(
     # ASTC
     elif target_texture_format.name.startswith("ASTC"):
         raw_img = img.tobytes("raw", "RGBA")
+        raw_img = astc_encoder.ASTCImage(
+            astc_encoder.ASTCType.U8, img.width, img.height, 1, raw_img
+        )
+        if img.mode == "RGB":
+            tex_format = getattr(TF, f"ASTC_RGB_{block_size[0]}x{block_size[1]}")
+        else:
+            tex_format = getattr(TF, f"ASTC_RGBA_{block_size[0]}x{block_size[1]}")
+
+        swizzle = astc_encoder.ASTCSwizzle.from_str("RGBA")
 
         block_size = tuple(
             map(int, target_texture_format.name.rsplit("_", 1)[1].split("x"))
         )
         context, lock = get_astc_context(block_size)
-
         with lock:
-            raw_img = astc_encoder.ASTCImage(
-                astc_encoder.ASTCType.U8, img.width, img.height, 1, raw_img
-            )
-            if img.mode == "RGB":
-                tex_format = getattr(TF, f"ASTC_RGB_{block_size[0]}x{block_size[1]}")
-            else:
-                tex_format = getattr(TF, f"ASTC_RGBA_{block_size[0]}x{block_size[1]}")
-
-            swizzle = astc_encoder.ASTCSwizzle.from_str("RGBA")
             enc_img = context.compress(raw_img, swizzle)
-            tex_format = target_texture_format
+
+        tex_format = target_texture_format
     # A
     elif target_texture_format == TF.Alpha8:
         enc_img = img.tobytes("raw", "A")
@@ -252,13 +252,13 @@ def atc(image_data: bytes, width: int, height: int, alpha: bool) -> Image.Image:
 
 
 def astc(image_data: bytes, width: int, height: int, block_size: tuple) -> Image.Image:
-    context, lock = get_astc_context(block_size)
+    image = astc_encoder.ASTCImage(astc_encoder.ASTCType.U8, width, height, 1)
+    texture_size = calculate_astc_compressed_size(width, height, block_size)
+    if len(image_data) < texture_size:
+        raise ValueError(f"Invalid ASTC data size: {len(image_data)} < {texture_size}")
 
+    context, lock = get_astc_context(block_size)
     with lock:
-        image = astc_encoder.ASTCImage(astc_encoder.ASTCType.U8, width, height, 1)
-        texture_size = calculate_astc_compressed_size(width, height, block_size)
-        if len(image_data) < texture_size:
-            raise ValueError(f"Invalid ASTC data size: {len(image_data)} < {texture_size}")
         context.decompress(
             image_data[:texture_size], image, astc_encoder.ASTCSwizzle.from_str("RGBA")
         )

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -4,7 +4,7 @@ import struct
 from copy import copy
 from io import BytesIO
 from threading import Lock
-from typing import TYPE_CHECKING, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
 import astc_encoder
 import texture2ddecoder
@@ -165,7 +165,7 @@ def parse_image_data(
     texture_format: Union[int, TextureFormat],
     version: tuple,
     platform: int,
-    platform_blob: Union[bytes, None] = None,
+    platform_blob: Optional[bytes] = None,
     flip: bool = True,
 ) -> Image.Image:
     image_data = copy(bytes(image_data))
@@ -229,7 +229,7 @@ def pillow(
     mode: str,
     codec: str,
     args,
-    swap: Union[tuple, None] = None,
+    swap: Optional[tuple] = None,
 ) -> Image.Image:
     img = (
         Image.frombytes(mode, (width, height), image_data, codec, args)
@@ -334,7 +334,7 @@ def half(
     mode: str,
     codec: str,
     args,
-    swap: Union[tuple, None] = None,
+    swap: Optional[tuple] = None,
 ) -> Image.Image:
     # convert half-float to int8
     stream = BytesIO(image_data)

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -76,7 +76,7 @@ def image_to_texture2d(
         )
 
         config = astc_encoder.ASTCConfig(
-            astc_encoder.ASTCProfile.LDR, *block_size, 1, 100
+            astc_encoder.ASTCProfile.LDR, *block_size, block_z=1, quality=100
         )
         context = astc_encoder.ASTCContext(config)
         raw_img = astc_encoder.ASTCImage(
@@ -166,7 +166,7 @@ def parse_image_data(
     texture_format: Union[int, TextureFormat],
     version: tuple,
     platform: int,
-    platform_blob: bytes = None,
+    platform_blob: Union[bytes, None] = None,
     flip: bool = True,
 ) -> Image.Image:
     image_data = copy(bytes(image_data))
@@ -230,7 +230,7 @@ def pillow(
     mode: str,
     codec: str,
     args,
-    swap: tuple = None,
+    swap: Union[tuple, None] = None,
 ) -> Image.Image:
     img = (
         Image.frombytes(mode, (width, height), image_data, codec, args)
@@ -327,7 +327,7 @@ def half(
     mode: str,
     codec: str,
     args,
-    swap: tuple = None,
+    swap: Union[tuple, None] = None,
 ) -> Image.Image:
     # convert half-float to int8
     stream = BytesIO(image_data)

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import struct
 from copy import copy
@@ -177,7 +177,7 @@ def parse_image_data(
 
     if len(selection) == 0:
         raise NotImplementedError(
-            f"Not implemented texture format: {texture_format.name}"
+            f"Not implemented texture format: {texture_format}"
         )
 
     if platform == BuildTarget.XBOX360 and texture_format in XBOX_SWAP_FORMATS:
@@ -356,7 +356,7 @@ def rg(
     padding = bytes(padding_size)
     rgb_data = b"".join(
         stream.read(padding_size * 2) + padding
-        for _ in range(image_data / (2 * padding_size))
+        for _ in range(len(image_data) // (2 * padding_size))
     )
     if codec == "RGE":
         return half(rgb_data, width, height, mode, "RGB", args)


### PR DESCRIPTION
## Summary

This PR mainly fixes the concurrent issue of ASTC context in `Texture2DConverter`. By the way, it also fixes some type errors and type hints in `Texture2DConverter`.

## 1. ASTC Context Concurrent Issue

### How do I discovered this issue:

After upgrading UnityPy (from 1.18 to 1.20) in my project [ArkUnpacker](https://github.com/isHarryh/Ark-Unpacker), I noticed that, when using multithreading to extract **images**, the application has an unpredictable chance to crash **without** any stacktrace (just like you shutdown the application in the Task Manager forcibly).

With the extensive debugging, I finally determined that it is the **asynchronous access to the ASTC context** that causes the problem.

This issue was caused by this commit d38b5f660d1c1f048413cb5dfa0464400f1038be which introduced `astc_encoder` for texture decoding.

### How to fix it:

Simply adding a `threading.Lock` to the dict `ASTC_CONTEXTS`.

## 2. Type Errors

There are two potential type errors. See my commit for detailed changes. Here comes the explanation:

1. In this case, `texture_format` may be an integer.

```python
        raise NotImplementedError(
-            f"Not implemented texture format: {texture_format.name}"
+            f"Not implemented texture format: {texture_format}"
        )
```

2. In this case, bytes cannot be divided by integer.

```python
    rgb_data = b"".join(
        stream.read(padding_size * 2) + padding
-        for _ in range(image_data / (2 * padding_size))
+        for _ in range(len(image_data) // (2 * padding_size))
    )
```