### PR TITLE
Fix some type hints (EndianBinaryReader, EndianBinaryWriter)

### DIFF
--- a/UnityPy/streams/EndianBinaryWriter.py
+++ b/UnityPy/streams/EndianBinaryWriter.py
@@ -9,7 +9,6 @@ from ..math import Color, Matrix4x4, Quaternion, Vector2, Vector3, Vector4, Rect
 
 class EndianBinaryWriter:
     endian: str
-    Length: int
     Position: int
     stream: IOBase
 
@@ -43,7 +42,6 @@ class EndianBinaryWriter:
 
     def dispose(self):
         self.stream.close()
-        pass
 
     def write(self, *args):
         if self.Position != self.stream.tell():
@@ -131,10 +129,10 @@ class EndianBinaryWriter:
         self.write_float(value.height)
 
     def write_color_uint(self, value: Color):
-        self.write_u_byte(value.R * 255)
-        self.write_u_byte(value.G * 255)
-        self.write_u_byte(value.B * 255)
-        self.write_u_byte(value.A * 255)
+        self.write_u_byte(int(value.R * 255))
+        self.write_u_byte(int(value.G * 255))
+        self.write_u_byte(int(value.B * 255))
+        self.write_u_byte(int(value.A * 255))
 
     def write_color4(self, value: Color):
         self.write_float(value.R)

--- a/UnityPy/streams/EndianBinaryWriter.py
+++ b/UnityPy/streams/EndianBinaryWriter.py
@@ -1,5 +1,8 @@
-import io
 from struct import pack
+from io import BytesIO, IOBase
+
+import builtins
+from typing import Callable, Union
 
 from ..math import Color, Matrix4x4, Quaternion, Vector2, Vector3, Vector4, Rectangle
 
@@ -8,13 +11,17 @@ class EndianBinaryWriter:
     endian: str
     Length: int
     Position: int
-    stream: io.BufferedReader
+    stream: IOBase
 
-    def __init__(self, input_=b"", endian=">"):
+    def __init__(
+        self,
+        input_: Union[bytes, bytearray, IOBase] = b"",
+        endian: str = ">"
+    ):
         if isinstance(input_, (bytes, bytearray)):
-            self.stream = io.BytesIO(input_)
+            self.stream = BytesIO(input_)
             self.stream.seek(0, 2)
-        elif isinstance(input_, io.IOBase):
+        elif isinstance(input_, IOBase):
             self.stream = input_
         else:
             raise ValueError("Invalid input type - %s." % type(input_))
@@ -51,7 +58,7 @@ class EndianBinaryWriter:
     def write_u_byte(self, value: int):
         self.write(pack(self.endian + "B", value))
 
-    def write_bytes(self, value: bytes):
+    def write_bytes(self, value: builtins.bytes):
         return self.write(value)
 
     def write_short(self, value: int):
@@ -91,7 +98,7 @@ class EndianBinaryWriter:
         self.write(bstring)
         self.align_stream(4)
 
-    def align_stream(self, alignment=4):
+    def align_stream(self, alignment:int = 4):
         pos = self.stream.tell()
         align = (alignment - pos % alignment) % alignment
         self.write(b"\0" * align)
@@ -139,13 +146,13 @@ class EndianBinaryWriter:
         for val in value.M:
             self.write_float(val)
 
-    def write_array(self, command, value: list, write_length: bool = True):
+    def write_array(self, command: Callable, value: list, write_length: bool = True):
         if write_length:
             self.write_int(len(value))
         for val in value:
             command(val)
 
-    def write_byte_array(self, value: bytes):
+    def write_byte_array(self, value: builtins.bytes):
         self.write_int(len(value))
         self.write(value)
 


### PR DESCRIPTION
## Summary

This PR mainly fixes some type hints in `EndianBinaryReader` and `EndianBinaryWriter`.

By the way, some minor code issues are fixed, including:

1. Legacy code lines (e.g. legacy `pass` statement) are removed.
2. Some imports and isinstance-checks are optimized.
3. Some potential errors (e.g. int conversion) are fixed.

For more details, please refer to the commits.
