### PR TITLE
TypeTreeHelper - Add missing `size` argument in `read_value_array`

### DIFF
--- a/UnityPy/classes/generated.py
+++ b/UnityPy/classes/generated.py
@@ -32,7 +32,7 @@ def unitypy_define(cls: T) -> T:
   which would make type-hinting more tricky, and breaks attrs.define.
 
   Therefore this function bypasses the issue
-  by redifining the bases for problematic classes for the attrs.define call.
+  by redefining the bases for problematic classes for the attrs.define call.
   """
   bases = cls.__bases__
   if bases[0] in (object, Object, ABC):

--- a/UnityPy/helpers/TypeTreeHelper.py
+++ b/UnityPy/helpers/TypeTreeHelper.py
@@ -84,7 +84,9 @@ class TypeTreeConfig:
         return TypeTreeConfig(self.as_dict, self.assetsfile, self.has_registry)
 
 
-def get_ref_type_node(ref_object: dict, assetfile: SerializedFile) -> Optional[TypeTreeNode]:
+def get_ref_type_node(
+    ref_object: dict, assetfile: SerializedFile
+) -> Optional[TypeTreeNode]:
     typ = ref_object["type"]
     if isinstance(typ, dict):
         cls = typ["class"]
@@ -209,7 +211,7 @@ def read_value(
         size = reader.read_int()
         subtype = node.m_Children[0].m_Children[1]
         if metaflag_is_aligned(subtype.m_MetaFlag):
-            value = read_value_array(subtype, reader, config)
+            value = read_value_array(subtype, reader, config, size)
         else:
             value = [read_value(subtype, reader, config) for _ in range(size)]
 

--- a/generators/ClassesGenerator.py
+++ b/generators/ClassesGenerator.py
@@ -75,7 +75,7 @@ def unitypy_define(cls: T) -> T:
   which would make type-hinting more tricky, and breaks attrs.define.
 
   Therefore this function bypasses the issue
-  by redifining the bases for problematic classes for the attrs.define call.
+  by redefining the bases for problematic classes for the attrs.define call.
   \"\"\"
   bases = cls.__bases__
   if bases[0] in (object, Object, ABC):


### PR DESCRIPTION
Title. The Python TypeTree reader implementation omitted `size` in this particular code path.