### PR TITLE
C TypeTreeHelper - Safeguard against bogus Array definition

### DIFF
--- a/UnityPyBoost/TypeTreeHelper.cpp
+++ b/UnityPyBoost/TypeTreeHelper.cpp
@@ -834,7 +834,7 @@ PyObject *read_typetree_value(ReaderT *reader, TypeTreeNodeObject *node, TypeTre
         if (child && child->_data_type == NodeDataType::Array)
         {
             // array
-            if (PyList_GET_SIZE(node->m_Children) != 2)
+            if (PyList_GET_SIZE(child->m_Children) != 2)
             {
                 PyErr_SetString(PyExc_ValueError, "Array node must have 2 children");
                 return NULL;

--- a/UnityPyBoost/TypeTreeHelper.cpp
+++ b/UnityPyBoost/TypeTreeHelper.cpp
@@ -834,6 +834,12 @@ PyObject *read_typetree_value(ReaderT *reader, TypeTreeNodeObject *node, TypeTre
         if (child && child->_data_type == NodeDataType::Array)
         {
             // array
+            if (PyList_GET_SIZE(node->m_Children) != 2)
+            {
+                PyErr_SetString(PyExc_ValueError, "Array node must have 2 children");
+                return NULL;
+            }
+
             if (child->_align)
             {
                 align = true;


### PR DESCRIPTION
The following TypeTree node dump generated by https://github.com/K0lb3/TypeTreeGenerator/tree/eb89afb059ce6b5e53633f2343b7deac406bc786 is malformed, and will crash the C implementation.
```json
{
  "Live2D.Cubism.Framework.MotionFade.CubismFadeMotionData": [
    {
      "m_Type": "MonoBehaviour",
      "m_Name": "Base",
      "m_MetaFlag": 0,
      "m_Level": 0
    },
    {
      "m_Type": "PPtr\u003CGameObject\u003E",
      "m_Name": "m_GameObject",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "int",
      "m_Name": "m_FileID",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "SInt64",
      "m_Name": "m_PathID",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "UInt8",
      "m_Name": "m_Enabled",
      "m_MetaFlag": 16384,
      "m_Level": 1
    },
    {
      "m_Type": "PPtr\u003CMonoScript\u003E",
      "m_Name": "m_Script",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "int",
      "m_Name": "m_FileID",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "SInt64",
      "m_Name": "m_PathID",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "string",
      "m_Name": "m_Name",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 16384,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "char",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "string",
      "m_Name": "MotionName",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 16384,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "char",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "float",
      "m_Name": "ModelFadeInTime",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "float",
      "m_Name": "ModelFadeOutTime",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "float",
      "m_Name": "FadeInTime",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "float",
      "m_Name": "FadeOutTime",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "String[]",
      "m_Name": "ParameterIds",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "string",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 16384,
      "m_Level": 4
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "char",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "AnimationCurve[]",
      "m_Name": "ParameterCurves",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "AnimationCurve",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 4
    },
    {
      "m_Type": "vector",
      "m_Name": "m_Curve",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 6
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 7
    },
    {
      "m_Type": "Keyframe",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 7
    },
    {
      "m_Type": "float",
      "m_Name": "time",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "float",
      "m_Name": "value",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "float",
      "m_Name": "inSlope",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "float",
      "m_Name": "outSlope",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "int",
      "m_Name": "weightedMode",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "float",
      "m_Name": "inWeight",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "float",
      "m_Name": "outWeight",
      "m_MetaFlag": 0,
      "m_Level": 8
    },
    {
      "m_Type": "int",
      "m_Name": "m_PreInfinity",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "int",
      "m_Name": "m_PostInfinity",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "int",
      "m_Name": "m_RotationOrder",
      "m_MetaFlag": 0,
      "m_Level": 5
    },
    {
      "m_Type": "Single[]",
      "m_Name": "ParameterFadeInTimes",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "float",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "Single[]",
      "m_Name": "ParameterFadeOutTimes",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "float",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "float",
      "m_Name": "MotionLength",
      "m_MetaFlag": 0,
      "m_Level": 1
    }
}
```

Specifically it's this part
```json
    {
      "m_Type": "AnimationCurve[]",
      "m_Name": "ParameterCurves",
      "m_MetaFlag": 0,
      "m_Level": 1
    },
    {
      "m_Type": "Array",
      "m_Name": "Array",
      "m_MetaFlag": 0,
      "m_Level": 2
    },
    {
      "m_Type": "int",
      "m_Name": "size",
      "m_MetaFlag": 0,
      "m_Level": 3
    },
    {
      "m_Type": "AnimationCurve",
      "m_Name": "data",
      "m_MetaFlag": 0,
      "m_Level": 4
    },
```
`AnimationCurve` should be level 3 in this case.