### PR TITLE
Improve config and files module

### DIFF
--- a/UnityPy/config.py
+++ b/UnityPy/config.py
@@ -1,20 +1,41 @@
-# used when no version is defined by the SerializedFile or its BundleFile
-FALLBACK_UNITY_VERSION = "2.5.0f5"
-# determines if the typetree structures for the Object types will be parsed
-# disabling this will reduce the load time by a lot (half of the time is spend on parsing the typetrees)
-#  but it will also prevent saving an edited file
-SERIALIZED_FILE_PARSE_TYPETREE = True
+import warnings
 
-# GLOBAL WARNING SUPPRESSION
-FALLBACK_VERSION_WARNED = False  # for FALLBACK_UNITY_VERSION
+from .exceptions import UnityVersionFallbackError, UnityVersionFallbackWarning
+
+
+FALLBACK_UNITY_VERSION = None
+"""The Unity version to use when no version is defined
+   by the SerializedFile or its BundleFile.
+
+   You may manually configure this value to a version string, e.g. `2.5.0f5`.
+"""
+
+SERIALIZED_FILE_PARSE_TYPETREE = True
+"""Determines if the typetree structures for the Object types will be parsed.
+
+   Disabling this will reduce the load time by a lot (half of the time is spend on parsing the typetrees),
+   but it will also prevent saving an edited file.
+"""
+
+
+# WARNINGS CONTROL
+warnings.simplefilter("once", UnityVersionFallbackWarning)
 
 
 # GET FUNCTIONS
 def get_fallback_version():
-    global FALLBACK_VERSION_WARNED
-    if not FALLBACK_VERSION_WARNED:
-        print(
-            f"Warning: 0.0.0 version found, defaulting to UnityPy.config.FALLBACK_UNITY_VERSION ({FALLBACK_UNITY_VERSION})"  # noqa: E501
+    global FALLBACK_UNITY_VERSION
+
+    if not isinstance(FALLBACK_UNITY_VERSION, str):
+        raise UnityVersionFallbackError(
+            "No valid Unity version found, and the fallback version is not correctly configured. "
+            + "Please explicitly set the value of UnityPy.config.FALLBACK_UNITY_VERSION."
         )
-        FALLBACK_VERSION_WARNED = True
+
+    warnings.warn(
+        f"No valid Unity version found, defaulting to UnityPy.config.FALLBACK_UNITY_VERSION ({FALLBACK_UNITY_VERSION})",  # noqa: E501
+        category=UnityVersionFallbackWarning,
+        stacklevel=2
+    )
+
     return FALLBACK_UNITY_VERSION

--- a/UnityPy/exceptions.py
+++ b/UnityPy/exceptions.py
@@ -1,5 +1,14 @@
 class TypeTreeError(Exception):
-    def __init__(self, message, nodes):            
-        # Call the base class constructor with the parameters it needs
+    def __init__(self, message, nodes):
         super().__init__(message)
         self.nodes = nodes
+
+
+class UnityVersionFallbackError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class UnityVersionFallbackWarning(UserWarning):
+    def __init__(self, message):
+        super().__init__(message)

--- a/UnityPy/files/BundleFile.py
+++ b/UnityPy/files/BundleFile.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, Union
 
 from . import File
 from ..enums import ArchiveFlags, ArchiveFlagsOld, CompressionFlags
+from ..exceptions import UnityVersionFallbackError
 from ..helpers import ArchiveStorageManager, CompressionHelper
 from ..streams import EndianBinaryReader, EndianBinaryWriter
 
@@ -531,6 +532,6 @@ class BundleFile(File.File):
         if not match:
             match = reVersion.match(config.get_fallback_version())
             if not match or len(match.groups()) < 3:
-                raise ValueError("Illegal fallback version format")
+                raise UnityVersionFallbackError("Illegal fallback version format")
         map_ = map(int, match.groups())
         return (next(map_), next(map_), next(map_))

--- a/UnityPy/files/BundleFile.py
+++ b/UnityPy/files/BundleFile.py
@@ -201,8 +201,8 @@ class BundleFile(File.File):
                 original - uses the original flags
         """
         # file_header
-        #     signature    (string_to_null)
-        #     format        (int)
+        #     signature         (string_to_null)
+        #     format            (int)
         #     version_player    (string_to_null)
         #     version_engine    (string_to_null)
         writer = EndianBinaryWriter()
@@ -252,11 +252,11 @@ class BundleFile(File.File):
         # data_flag
 
         # header:
-        #     bundle_size        (long)
-        #     compressed_size    (int)
-        #     uncompressed_size    (int)
-        #     flag                (int)
-        #     ?padding?            (bool)
+        #     bundle_size       (long)
+        #     compressed_size   (int)
+        #     uncompressed_size (int)
+        #     flag              (int)
+        #     ?padding?         (bool)
         #   This will be written at the end,
         #   because the size can only be calculated after the data compression,
 
@@ -266,21 +266,21 @@ class BundleFile(File.File):
         #     *read compressed_size -> uncompressed_size
         #     0x10 offset
         #     *read blocks infos of the data stream
-        #     count            (int)
+        #     count                 (int)
         #     (
-        #         uncompressed_size(uint)
-        #         compressed_size (uint)
-        #         flag(short)
+        #         uncompressed_size (uint)
+        #         compressed_size   (uint)
+        #         flag              (short)
         #     )
         #     *decompression via info.flag & 0x3F
 
         #     *afterwards the file positions
-        #     file_count        (int)
+        #     file_count    (int)
         #     (
         #         offset    (long)
-        #         size        (long)
-        #         flag        (int)
-        #         name        (string_to_null)
+        #         size      (long)
+        #         flag      (int)
+        #         name      (string_to_null)
         #     )
 
         # file list & file data

--- a/UnityPy/files/File.py
+++ b/UnityPy/files/File.py
@@ -95,7 +95,7 @@ class File:
             f.flags = getattr(node, "flags", 0)
             self.files[name] = f
 
-    def get_writeable_cab(self, name: str = None):
+    def get_writeable_cab(self, name: Optional[str] = None):
         """
         Creates a new cab file in the bundle that contains the given data.
         This is useful for asset types that use resource files.

--- a/UnityPy/files/File.py
+++ b/UnityPy/files/File.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 DirectoryInfo = namedtuple("DirectoryInfo", "path offset size")
 
 
-class File(object):
+class File:
     name: str
     files: Dict[str, File]
     environment: Environment
@@ -34,7 +34,7 @@ class File(object):
         self.is_changed = False
         self.cab_file = "CAB-UnityPy_Mod.resS"
         self.parent = parent
-        self.environment = self.environment = (
+        self.environment = (
             getattr(parent, "environment", parent) if parent else None
         )
         self.name = basename(name) if isinstance(name, str) else ""
@@ -98,7 +98,7 @@ class File(object):
     def get_writeable_cab(self, name: str = None):
         """
         Creates a new cab file in the bundle that contains the given data.
-        This is usefull for asset types that use resource files.
+        This is useful for asset types that use resource files.
         """
 
         if not name:

--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -152,9 +152,11 @@ class ObjectReader(Generic[T]):
             writer.write_u_short(self.class_id)
 
         if header.version < 11:
+            assert self.is_destroyed is not None
             writer.write_u_short(self.is_destroyed)
 
         if 11 <= header.version < 17:
+            assert self.serialized_type is not None
             writer.write_short(self.serialized_type.script_type_index)
 
         if header.version == 15 or header.version == 16:

--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -256,7 +256,7 @@ class ObjectReader(Generic[T]):
         self,
         tree: dict,
         nodes: Optional[Union[TypeTreeNode, List[dict[str, Union[str, int]]]]] = None,
-        writer: EndianBinaryWriter = None,
+        writer: Optional[EndianBinaryWriter] = None,
     ):
         node = self._get_typetree_node(nodes)
         if not writer:

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import re
 from ntpath import basename
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Generator, Iterator, List, Optional, Tuple
 
 from attrs import define
 
@@ -24,7 +24,7 @@ class SerializedFileHeader:
     file_size: int
     version: int
     data_offset: int
-    endian: bytes
+    endian: str
     reserved: bytes
 
     def __init__(self, reader: EndianBinaryReader):
@@ -115,7 +115,7 @@ class BuildType:
 class SerializedType:
     class_id: int
     is_stripped_type: Optional[bool] = None
-    script_type_index: Optional[int] = -1
+    script_type_index: int = -1
     script_id: Optional[bytes] = None  # Hash128
     old_type_hash: Optional[bytes] = None  # Hash128
     node: Optional[TypeTreeNode] = None
@@ -124,7 +124,7 @@ class SerializedType:
     m_NameSpace: Optional[str] = None
     m_AssemblyName: Optional[str] = None
     # 21+
-    type_dependencies: Optional[List[int]] = None
+    type_dependencies: Optional[Tuple[int, ...]] = None
 
     def __init__(
         self,
@@ -215,7 +215,7 @@ class SerializedType:
                     writer.write_int_array(self.type_dependencies, True)
 
     @property
-    def nodes(self) -> Union[TypeTreeNode, None]:
+    def nodes(self) -> Optional[TypeTreeNode]:
         # for compatibility with old versions
         return self.node
 
@@ -236,8 +236,7 @@ class SerializedFile(File.File):
     _m_target_platform: int
     big_id_enabled: int
     userInformation: Optional[str]
-    assetbundle: AssetBundle
-    container: ContainerHelper
+    assetbundle: Optional[AssetBundle]
     _cache: Dict[str, Object]
 
     @property
@@ -414,7 +413,7 @@ class SerializedFile(File.File):
 
         return cab
 
-    def save(self, packer: str = None) -> bytes:
+    def save(self, packer: Optional[str] = None) -> bytes:
         # 1. header -> has to be delayed until the very end
         # 2. data -> types, objects, scripts, ...
 
@@ -567,7 +566,7 @@ class ContainerHelper:
     def __delitem__(self, key) -> None:
         raise NotImplementedError("Deleting from the container is not allowed!")
 
-    def __iter__(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Iterator[str]:
         return iter(self.keys())
 
     def __len__(self) -> int:

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -576,9 +576,6 @@ class ContainerHelper:
     def __getattr__(self, name: str) -> PPtr[Object]:
         return self.container_dict[name]
 
-    def __or__(self, other: ContainerHelper):
-        return ContainerHelper(list(set(self.container + other.container)))
-
     def __str__(self) -> str:
         return f'{{{", ".join(f"{key}: {value}" for key, value in self.items())}}}'
 

--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import re
 from ntpath import basename
@@ -83,8 +83,13 @@ class FileIdentifier:  # external
 
     def write(self, header: SerializedFileHeader, writer: EndianBinaryWriter):
         if header.version >= 6:
+            assert self.temp_empty is not None
             writer.write_string_to_null(self.temp_empty)
         if header.version >= 5:
+            assert (
+                self.guid is not None
+                and self.type is not None
+            )
             writer.write_bytes(self.guid)
             writer.write_int(self.type)
         writer.write_string_to_null(self.path)
@@ -170,9 +175,11 @@ class SerializedType:
         writer.write_int(self.class_id)
 
         if version >= 16:
+            assert self.is_stripped_type is not None
             writer.write_boolean(self.is_stripped_type)
 
         if version >= 17:
+            assert self.script_type_index is not None
             writer.write_short(self.script_type_index)
 
         if version >= 13:
@@ -181,7 +188,9 @@ class SerializedType:
                 or (version < 16 and self.class_id < 0)
                 or (version >= 16 and self.class_id == 114)
             ):
+                assert self.script_id is not None
                 writer.write_bytes(self.script_id)  # Hash128
+            assert self.old_type_hash is not None
             writer.write_bytes(self.old_type_hash)  # Hash128
 
         if serialized_file._enable_type_tree:
@@ -193,10 +202,16 @@ class SerializedType:
 
             if version >= 21:
                 if is_ref_type:
+                    assert (
+                        self.m_ClassName is not None
+                        and self.m_NameSpace is not None
+                        and self.m_AssemblyName is not None
+                    )
                     writer.write_string_to_null(self.m_ClassName)
                     writer.write_string_to_null(self.m_NameSpace)
                     writer.write_string_to_null(self.m_AssemblyName)
                 else:
+                    assert self.type_dependencies is not None
                     writer.write_int_array(self.type_dependencies, True)
 
     @property
@@ -443,11 +458,13 @@ class SerializedFile(File.File):
             external.write(header, meta_writer)
 
         if header.version >= 20:
+            assert self.ref_types is not None
             meta_writer.write_int(len(self.ref_types))
             for ref_type in self.ref_types:
                 ref_type.write(self, meta_writer, True)
 
         if header.version >= 5:
+            assert self.userInformation is not None
             meta_writer.write_string_to_null(self.userInformation)
 
         # prepare header

--- a/UnityPy/files/WebFile.py
+++ b/UnityPy/files/WebFile.py
@@ -1,4 +1,6 @@
-﻿from . import File
+﻿from typing import Optional
+
+from . import File
 from ..helpers import CompressionHelper
 from ..streams import EndianBinaryReader, EndianBinaryWriter
 
@@ -55,7 +57,7 @@ class WebFile(File.File):
 
     def save(
         self,
-        files: dict = None,
+        files: Optional[dict] = None,
         packer: str = "none",
         signature: str = "UnityWebData1.0",
     ) -> bytes:

--- a/UnityPy/helpers/Tpk.py
+++ b/UnityPy/helpers/Tpk.py
@@ -475,7 +475,7 @@ class TpkStringBuffer:
 class TpkCommonString:
     __slots__ = ("VersionInformation", "StringBufferIndices")
     VersionInformation: List[Tuple[UnityVersion, int]]
-    StringBufferIndices: Tuple[int]
+    StringBufferIndices: Tuple[int, ...]
 
     def __init__(self, stream: BytesIO) -> None:
         (versionCount,) = INT32.unpack(stream.read(INT32.size))

--- a/UnityPy/streams/EndianBinaryReader.py
+++ b/UnityPy/streams/EndianBinaryReader.py
@@ -208,39 +208,39 @@ class EndianBinaryReader:
         struct = Struct(f"{self.endian}{length}{param}")
         return struct.unpack(self.read(struct.size))
 
-    def read_boolean_array(self, length: Optional[int] = None) -> Tuple[bool]:
+    def read_boolean_array(self, length: Optional[int] = None) -> Tuple[bool, ...]:
         return self.read_array_struct("?", length)
 
-    def read_u_byte_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_u_byte_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("B", length)
 
-    def read_u_short_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_u_short_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("h", length)
 
-    def read_short_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_short_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("H", length)
 
-    def read_int_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_int_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("i", length)
 
-    def read_u_int_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_u_int_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("I", length)
 
-    def read_long_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_long_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("q", length)
 
-    def read_u_long_array(self, length: Optional[int] = None) -> Tuple[int]:
+    def read_u_long_array(self, length: Optional[int] = None) -> Tuple[int, ...]:
         return self.read_array_struct("Q", length)
 
-    def read_u_int_array_array(self, length: Optional[int] = None) -> List[Tuple[int]]:
+    def read_u_int_array_array(self, length: Optional[int] = None) -> List[Tuple[int, ...]]:
         return self.read_array(
             self.read_u_int_array, length if length is not None else self.read_int()
         )
 
-    def read_float_array(self, length: Optional[int] = None) -> Tuple[float]:
+    def read_float_array(self, length: Optional[int] = None) -> Tuple[float, ...]:
         return self.read_array_struct("f", length)
 
-    def read_double_array(self, length: Optional[int] = None) -> Tuple[float]:
+    def read_double_array(self, length: Optional[int] = None) -> Tuple[float, ...]:
         return self.read_array_struct("d", length)
 
     def read_string_array(self) -> List[str]:

--- a/UnityPy/streams/EndianBinaryWriter.py
+++ b/UnityPy/streams/EndianBinaryWriter.py
@@ -2,7 +2,7 @@ from struct import pack
 from io import BytesIO, IOBase
 
 import builtins
-from typing import Callable, Union
+from typing import Callable, Sequence, Union
 
 from ..math import Color, Matrix4x4, Quaternion, Vector2, Vector3, Vector4, Rectangle
 
@@ -144,7 +144,7 @@ class EndianBinaryWriter:
         for val in value.M:
             self.write_float(val)
 
-    def write_array(self, command: Callable, value: list, write_length: bool = True):
+    def write_array(self, command: Callable, value: Sequence, write_length: bool = True):
         if write_length:
             self.write_int(len(value))
         for val in value:
@@ -154,29 +154,29 @@ class EndianBinaryWriter:
         self.write_int(len(value))
         self.write(value)
 
-    def write_boolean_array(self, value: list):
+    def write_boolean_array(self, value: Sequence):
         self.write_array(self.write_boolean, value)
 
-    def write_u_short_array(self, value: list):
+    def write_u_short_array(self, value: Sequence):
         self.write_array(self.write_u_short, value)
 
-    def write_int_array(self, value: list, write_length: bool = False):
+    def write_int_array(self, value: Sequence, write_length: bool = False):
         return self.write_array(self.write_int, value, write_length)
 
-    def write_u_int_array(self, value: list, write_length: bool = False):
+    def write_u_int_array(self, value: Sequence, write_length: bool = False):
         return self.write_array(self.write_u_int, value, write_length)
 
-    def write_float_array(self, value: list, write_length: bool = False):
+    def write_float_array(self, value: Sequence, write_length: bool = False):
         return self.write_array(self.write_float, value, write_length)
 
-    def write_string_array(self, value: list):
+    def write_string_array(self, value: Sequence):
         self.write_array(self.write_aligned_string, value)
 
-    def write_vector2_array(self, value: list):
+    def write_vector2_array(self, value: Sequence):
         self.write_array(self.write_vector2, value)
 
-    def write_vector4_array(self, value: list):
+    def write_vector4_array(self, value: Sequence):
         self.write_array(self.write_vector4, value)
 
-    def write_matrix_array(self, value: list):
+    def write_matrix_array(self, value: Sequence):
         self.write_array(self.write_matrix, value)

--- a/UnityPy/streams/EndianBinaryWriter.py
+++ b/UnityPy/streams/EndianBinaryWriter.py
@@ -2,9 +2,11 @@ from struct import pack
 from io import BytesIO, IOBase
 
 import builtins
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence, TypeVar, Union
 
 from ..math import Color, Matrix4x4, Quaternion, Vector2, Vector3, Vector4, Rectangle
+
+T = TypeVar("T")
 
 
 class EndianBinaryWriter:
@@ -144,7 +146,7 @@ class EndianBinaryWriter:
         for val in value.M:
             self.write_float(val)
 
-    def write_array(self, command: Callable, value: Sequence, write_length: bool = True):
+    def write_array(self, command: Callable[[T], None], value: Sequence[T], write_length: bool = True):
         if write_length:
             self.write_int(len(value))
         for val in value:
@@ -154,29 +156,29 @@ class EndianBinaryWriter:
         self.write_int(len(value))
         self.write(value)
 
-    def write_boolean_array(self, value: Sequence):
+    def write_boolean_array(self, value: Sequence[bool]):
         self.write_array(self.write_boolean, value)
 
-    def write_u_short_array(self, value: Sequence):
+    def write_u_short_array(self, value: Sequence[int]):
         self.write_array(self.write_u_short, value)
 
-    def write_int_array(self, value: Sequence, write_length: bool = False):
+    def write_int_array(self, value: Sequence[int], write_length: bool = False):
         return self.write_array(self.write_int, value, write_length)
 
-    def write_u_int_array(self, value: Sequence, write_length: bool = False):
+    def write_u_int_array(self, value: Sequence[int], write_length: bool = False):
         return self.write_array(self.write_u_int, value, write_length)
 
-    def write_float_array(self, value: Sequence, write_length: bool = False):
+    def write_float_array(self, value: Sequence[float], write_length: bool = False):
         return self.write_array(self.write_float, value, write_length)
 
-    def write_string_array(self, value: Sequence):
+    def write_string_array(self, value: Sequence[str]):
         self.write_array(self.write_aligned_string, value)
 
-    def write_vector2_array(self, value: Sequence):
+    def write_vector2_array(self, value: Sequence[Vector2]):
         self.write_array(self.write_vector2, value)
 
-    def write_vector4_array(self, value: Sequence):
+    def write_vector4_array(self, value: Sequence[Vector4]):
         self.write_array(self.write_vector4, value)
 
-    def write_matrix_array(self, value: Sequence):
+    def write_matrix_array(self, value: Sequence[Matrix4x4]):
         self.write_array(self.write_matrix, value)


### PR DESCRIPTION
## Summary

This PR makes code quality improvements to the files module, such as type hints and typo corrections.

## Commit Details

### 1. fix: better type hint in EndianBinaryReader/Writer

In `EndianBinaryReader`, use `-> Tuple[xxx, ...]` instead of `-> Tuple[xxx]`, where the latter one is a common mistake.

In `EndianBinaryWriter`, use `value: Sequence` instead of `value: list` because some invocations pass a tuple argument instead of list.

### 2. refactor(files): use assertion for version-specific assignment

Use `assert xxx is not None` before value assignment.

This is also the practice adopted by `MeshHelper` and other classes, which can correctly satisfy the NoneType checking.

### 3. chore(files): fix typo and remove legacy code

In `File` class:
- `class File(object)` can be simplified to `class File` (Python 3).
- `self.environment = self.environment = ...` causes a duplicated self-assignment.

In `ContainerHelper`, method `__or__` cannot be used anymore since 5ac0a62c59102ee0c53ad265d7d589d6ad6e7ccd changed the constructor of this class.

### 4. fix(files): overall type hint corrections

Correct the type hints in the files module.

Refactors `BundleFile.get_version_tuple`:
- Uses `(next(...), next(...), next(...))` instead of `tuple(map(...))` to respect the returned type `-> Tuple[int, int, int]`.
- Prevents `AttributeError` by validating the regex match before accessing `groups`.

> **Updates with 2 commits:**  
> 
> ### 1. fix(files): use generic type in EndianBinaryWriter
>
> Applies generic type to `Sequence` and `Callable` in `EndianBinaryWriter`.
> ### 2. feat(config): unset default fallback version
>
> Sets the `FALLBACK_UNITY_VERSION` to `None` (unset).
>
> Raises `UnityVersionFallbackError` when the fallback version is unset or invalid.
>
> Refactors the warning mechanism using the `warnings` module.
>
> Optimizes the documents string of the constants in the config.