### PR TITLE
Refactor the converter table in Texture2DConverter

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import struct
 from io import BytesIO


### PR DESCRIPTION
### Summary

This PR refactors the `CONV_TABLE` and it related code.

- Before: `{ TF -> (function, arg1, arg2, ...) }`
- After: `{ TF -> (function, (arg1, arg2, ...)) }`

This PR also:

1. Fixes a typo (that could cause error) in `CONV_TABLE` where `EAC_R:SIGNED` should be `EAC_R_SIGNED`.
2. Changes the `fmt` argument of `etc` function to maintain consistency with `eac`.

### Rationality

1. Clearly separate function and its additional arguments.


2. Resolves `typing_extensions` import error.  
   In 035cb09fb8383e9153282c9eb757fab697bcb177 , `typing_extensions` package has been introduced to `Texture2DConverter` to provide the `Unpack` type hint. However, this package is not a standard library, so it is **not installed** in some Python environments, causing `ModuleNotFoundError`. Adding this package to UnityPy's dependencies explicitly can solve this error, but it is not worth it.

> This PR is a part of #318
