### PR TITLE
fix Texture2D import for dxt5 swizzle

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -226,8 +226,8 @@ def image_to_texture2d(
             s_tex_format = tex_format
             block_size = TextureSwizzler.TEXTUREFORMAT_BLOCK_SIZE_MAP[s_tex_format]
             width, height = TextureSwizzler.get_padded_texture_size(
-            img.width, img.height, *block_size, gobsPerBlock
-        )
+                img.width, img.height, *block_size, gobsPerBlock
+            )
         width, height = get_compressed_image_size(width, height, tex_format)
         img = pad_image(img, width, height)
         enc_img = compress_func(

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -219,22 +219,9 @@ def image_to_texture2d(
         tex_format = TF.RGB24
         pil_mode = "RGB"
     # everything else defaulted to RGBA
-    if compress_func:
-        width, height = img.width, img.height
-        if TextureSwizzler.is_switch_swizzled(platform, platform_blob):
-            gobsPerBlock = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
-            s_tex_format = tex_format
-            block_size = TextureSwizzler.TEXTUREFORMAT_BLOCK_SIZE_MAP[s_tex_format]
-            width, height = TextureSwizzler.get_padded_texture_size(
-                img.width, img.height, *block_size, gobsPerBlock
-            )
-        width, height = get_compressed_image_size(width, height, tex_format)
-        img = pad_image(img, width, height)
-        enc_img = compress_func(
-            img.tobytes("raw", "RGBA"), img.width, img.height, tex_format
-        )
-    else:
-        enc_img = img.tobytes("raw", pil_mode)
+
+    width, height = img.width, img.height
+    switch_info = None
 
     if TextureSwizzler.is_switch_swizzled(platform, platform_blob):
         if TYPE_CHECKING:
@@ -252,11 +239,22 @@ def image_to_texture2d(
         width, height = TextureSwizzler.get_padded_texture_size(
             img.width, img.height, *block_size, gobsPerBlock
         )
-        if not compress_func:
-            # recompress with padding and corrected image mode
-            img = pad_image(img, width, height)
-            enc_img = img.tobytes("raw", pil_mode)
+        switch_info = (block_size, gobsPerBlock)
 
+    if compress_func:
+        width, height = get_compressed_image_size(width, height, tex_format)
+        img = pad_image(img, width, height)
+        enc_img = compress_func(
+            img.tobytes("raw", "RGBA"), img.width, img.height, tex_format
+        )
+    else:
+        if switch_info is not None:
+            img = pad_image(img, width, height)
+
+        enc_img = img.tobytes("raw", pil_mode)
+
+    if switch_info is not None:
+        block_size, gobsPerBlock = switch_info
         enc_img = bytes(
             TextureSwizzler.swizzle(enc_img, width, height, *block_size, gobsPerBlock)
         )

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -220,7 +220,15 @@ def image_to_texture2d(
         pil_mode = "RGB"
     # everything else defaulted to RGBA
     if compress_func:
-        width, height = get_compressed_image_size(img.width, img.height, tex_format)
+        width, height = img.width, img.height
+        if TextureSwizzler.is_switch_swizzled(platform, platform_blob):
+            gobsPerBlock = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
+            s_tex_format = tex_format
+            block_size = TextureSwizzler.TEXTUREFORMAT_BLOCK_SIZE_MAP[s_tex_format]
+            width, height = TextureSwizzler.get_padded_texture_size(
+            img.width, img.height, *block_size, gobsPerBlock
+        )
+        width, height = get_compressed_image_size(width, height, tex_format)
         img = pad_image(img, width, height)
         enc_img = compress_func(
             img.tobytes("raw", "RGBA"), img.width, img.height, tex_format


### PR DESCRIPTION
As for dxt5 format, padding for swizzle format should be previous than padding for compress. 

This should fix https://github.com/K0lb3/UnityPy/issues/319
` lvalue and rvalue have different structures`  because of the swizzle size if wrong. 

Here's the preview of the import texture2D. 

![f0912952-fe9e-4ea1-8fff-4421a96ec71d](https://github.com/user-attachments/assets/17bb6b98-1696-4b16-8c29-c07a4b3bf1ad)
