### PR TITLE
Cleanup Texture2DConverter and fix typos in pyproject.toml

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -214,7 +214,7 @@ def image_to_texture2d(
 
         assert platform_blob is not None
         gobs_per_block = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
-        block_size = TextureSwizzler.TEXTUREFORMAT_BLOCK_SIZE_MAP[s_tex_format]
+        block_size = TextureSwizzler.TEXTURE_FORMAT_BLOCK_SIZE_MAP[s_tex_format]
         width, height = TextureSwizzler.get_padded_texture_size(img.width, img.height, *block_size, gobs_per_block)
         switch_info = (block_size, gobs_per_block)
 
@@ -285,7 +285,7 @@ def parse_image_data(
 
         assert platform_blob is not None
         gobs_per_block = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
-        block_size = TextureSwizzler.TEXTUREFORMAT_BLOCK_SIZE_MAP[texture_format]
+        block_size = TextureSwizzler.TEXTURE_FORMAT_BLOCK_SIZE_MAP[texture_format]
         width, height = TextureSwizzler.get_padded_texture_size(width, height, *block_size, gobs_per_block)
         image_data = TextureSwizzler.deswizzle(image_data, width, height, *block_size, gobs_per_block)
     else:

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -299,7 +299,9 @@ def parse_image_data(
     else:
         width, height = get_compressed_image_size(width, height, texture_format)
 
-    image_data = bytes(image_data)
+    if not isinstance(image_data, bytes):
+        # bytes(bytes item) would cause an unnecessary copy
+        image_data = bytes(image_data)
 
     if "Crunched" in texture_format.name:
         if (

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -215,7 +215,9 @@ def image_to_texture2d(
         assert platform_blob is not None
         gobs_per_block = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
         block_size = TextureSwizzler.TEXTURE_FORMAT_BLOCK_SIZE_MAP[s_tex_format]
-        width, height = TextureSwizzler.get_padded_texture_size(img.width, img.height, *block_size, gobs_per_block)
+        width, height = TextureSwizzler.get_padded_texture_size(
+            img.width, img.height, *block_size, gobs_per_block
+        )
         switch_info = (block_size, gobs_per_block)
 
     if compress_func:
@@ -230,7 +232,9 @@ def image_to_texture2d(
 
     if switch_info:
         block_size, gobs_per_block = switch_info
-        enc_img = bytes(TextureSwizzler.swizzle(enc_img, width, height, *block_size, gobs_per_block))
+        enc_img = bytes(
+            TextureSwizzler.swizzle(enc_img, width, height, *block_size, gobs_per_block)
+        )
 
     return enc_img, tex_format
 
@@ -286,8 +290,12 @@ def parse_image_data(
         assert platform_blob is not None
         gobs_per_block = TextureSwizzler.get_switch_gobs_per_block(platform_blob)
         block_size = TextureSwizzler.TEXTURE_FORMAT_BLOCK_SIZE_MAP[texture_format]
-        width, height = TextureSwizzler.get_padded_texture_size(width, height, *block_size, gobs_per_block)
-        image_data = TextureSwizzler.deswizzle(image_data, width, height, *block_size, gobs_per_block)
+        width, height = TextureSwizzler.get_padded_texture_size(
+            width, height, *block_size, gobs_per_block
+        )
+        image_data = TextureSwizzler.deswizzle(
+            image_data, width, height, *block_size, gobs_per_block
+        )
     else:
         width, height = get_compressed_image_size(width, height, texture_format)
 

--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -4,6 +4,7 @@ import struct
 from io import BytesIO
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import astc_encoder
 import texture2ddecoder
@@ -117,11 +118,12 @@ def compress_astc(data: bytes, width: int, height: int, target_texture_format: T
 
 def image_to_texture2d(
     img: Image.Image,
-    target_texture_format: Union[TF, int],
-    platform: int = 0,
+    target_texture_format: Union[TextureFormat, int],
+    platform: Union[BuildTarget, int] = 0,
     platform_blob: Optional[List[int]] = None,
     flip: bool = True,
 ) -> Tuple[bytes, TextureFormat]:
+    """Converts a PIL Image to Texture2D bytes."""
     if not isinstance(target_texture_format, TextureFormat):
         target_texture_format = TextureFormat(target_texture_format)
 
@@ -178,7 +180,7 @@ def image_to_texture2d(
     elif target_texture_format == TF.Alpha8:
         tex_format = TF.Alpha8
         pil_mode = "A"
-    # R - should probably be moerged into #A, as pure R is used as Alpha
+    # R - should probably be merged into #A, as pure R is used as Alpha
     # but need test data for this first
     elif target_texture_format in [
         TF.R8,
@@ -244,15 +246,7 @@ def get_image_from_texture2d(
     texture_2d: Texture2D,
     flip: bool = True,
 ) -> Image.Image:
-    """converts the given texture into PIL.Image
-
-    :param texture_2d: texture to be converterd
-    :type texture_2d: Texture2D
-    :param flip: flips the image back to the original (all Unity textures are flipped by default)
-    :type flip: bool
-    :return: PIL.Image object
-    :rtype: Image
-    """
+    """Converts the given Texture2D object to PIL Image."""
     return parse_image_data(
         texture_2d.get_image_data(),
         texture_2d.m_Width,
@@ -269,12 +263,13 @@ def parse_image_data(
     image_data: Union[bytes, bytearray, memoryview],
     width: int,
     height: int,
-    texture_format: Union[int, TextureFormat],
+    texture_format: Union[TextureFormat, int],
     version: Tuple[int, int, int, int],
-    platform: int,
-    platform_blob: Optional[bytes] = None,
+    platform: Union[BuildTarget, int],
+    platform_blob: Optional[List[int]] = None,
     flip: bool = True,
 ) -> Image.Image:
+    """Converts the given image data bytes to PIL Image."""
     if not width or not height:
         return Image.new("RGBA", (0, 0))
 
@@ -333,9 +328,7 @@ def parse_image_data(
 
 
 def swap_bytes_for_xbox(image_data: Union[bytes, bytearray, memoryview]) -> bytearray:
-    """swaps the texture bytes
-    This is required for textures deployed on XBOX360.
-    """
+    """Swaps the texture bytes for textures deployed on XBOX360."""
     image_data = bytearray(image_data)
     for i in range(0, len(image_data), 2):
         image_data[i : i + 2] = image_data[i : i + 2][::-1]

--- a/UnityPy/helpers/TextureSwizzler.py
+++ b/UnityPy/helpers/TextureSwizzler.py
@@ -1,5 +1,6 @@
 # based on https://github.com/nesrak1/AssetsTools.NET/blob/dev/AssetsTools.NET.Texture/Swizzle/SwitchSwizzle.cs
 from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from ..enums import BuildTarget, TextureFormat
 
@@ -118,7 +119,9 @@ def get_switch_gobs_per_block(platform_blob: List[int]) -> int:
     return 1 << int.from_bytes(platform_blob[8:12], "little")
 
 
-def is_switch_swizzled(platform: Union[BuildTarget, int], platform_blob: Optional[List[int]]) -> bool:
+def is_switch_swizzled(
+    platform: Union[BuildTarget, int], platform_blob: Optional[List[int]]
+) -> bool:
     if platform != BuildTarget.Switch:
         return False
     if not platform_blob or len(platform_blob) < 12:

--- a/UnityPy/helpers/TextureSwizzler.py
+++ b/UnityPy/helpers/TextureSwizzler.py
@@ -70,7 +70,7 @@ def swizzle(
 
 
 # this should be the amount of pixels that can fit 16 bytes
-TEXTUREFORMAT_BLOCK_SIZE_MAP: Dict[TextureFormat, Tuple[int, int]] = {
+TEXTURE_FORMAT_BLOCK_SIZE_MAP: Dict[TextureFormat, Tuple[int, int]] = {
     TextureFormat.Alpha8: (16, 1),  # 1 byte per pixel
     TextureFormat.ARGB4444: (8, 1),  # 2 bytes per pixel
     TextureFormat.RGBA32: (4, 1),  # 4 bytes per pixel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "unity",
     "unity-asset",
     "python3",
-    "data-minig",
+    "data-mining",
     "unitypack",
     "assetstudio",
     "unity-asset-extractor",
@@ -43,9 +43,9 @@ dependencies = [
     "brotli", # WebFile compression
     # Texture & Sprite handling
     "Pillow",
-    "texture2ddecoder >= 1.0.5",         # texture decompression
-    "etcpak",                   # ETC & DXT compression
-    "astc-encoder-py >= 0.1.8", # ASTC compression
+    "texture2ddecoder >= 1.0.5", # texture decompression
+    "etcpak",                    # ETC & DXT compression
+    "astc-encoder-py >= 0.1.8",  # ASTC compression
     # audio extraction
     "pyfmodex >= 0.7.1",
     # filesystem handling


### PR DESCRIPTION
### Summary

This PR does some minor changes to Texture2DConverter.

- ~~`platform_blob` can be `List[int]` in newer version of Unity, instead of only `bytes`.~~
- One `platform_blob` type hint still uses `bytes`, now corrected to `List[int]`.
- `if TYPE_CHECKING: assert xxx is not None` seems redundant, now removed `if`.
- ~~Pre-converts `platform` to `BuildTarget` enum.~~
- ~~Wraps swizzle texture_format conversion into TextureSwizzler.~~
- Simplifies the redundant if-statements in `image_to_texture2d`.
- Optimizes docstrings and typos.

Along with two typo fixes in the `pyproject.toml`:

- ~~Fixes the invalid license field in `pyproject.toml` which causes CodeQL failing.~~
- Fixes the typo of the keyword `data-minig` in `pyproject.toml`.
