### PR TITLE
Prepend monobehaviour base fields to generated typetrees

### DIFF
--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -311,7 +311,7 @@ class ObjectReader(Generic[T]):
         else:
             fullname = script.m_ClassName
 
-        node = generator.get_nodes_up(script.m_AssemblyName, fullname)
+        node = generator.get_nodes_up(base_node, script.m_AssemblyName, fullname)
         if node:
             return node
         else:

--- a/UnityPy/files/ObjectReader.py
+++ b/UnityPy/files/ObjectReader.py
@@ -305,7 +305,13 @@ class ObjectReader(Generic[T]):
             raise ValueError("No typetree generator set!")
         monobehaviour = cast(MonoBehaviour, self.parse_as_object(base_node, check_read=False))
         script = monobehaviour.m_Script.deref_parse_as_object()
-        node = generator.get_nodes_up(script.m_AssemblyName, f"{script.m_Namespace}.{script.m_ClassName}")
+
+        if script.m_Namespace != "":
+            fullname = f"{script.m_Namespace}.{script.m_ClassName}"
+        else:
+            fullname = script.m_ClassName
+
+        node = generator.get_nodes_up(script.m_AssemblyName, fullname)
         if node:
             return node
         else:

--- a/UnityPy/helpers/TypeTreeGenerator.py
+++ b/UnityPy/helpers/TypeTreeGenerator.py
@@ -43,7 +43,7 @@ class TypeTreeGenerator(TypeTreeGeneratorBase):
                 data = f.read()
                 self.load_dll(data)
 
-    def get_nodes_up(self, assembly: str, fullname: str) -> TypeTreeNode:
+    def get_nodes_up(self, base_node: TypeTreeNode, assembly: str, fullname: str) -> TypeTreeNode:
         root = self.cache.get((assembly, fullname))
         if root is not None:
             return root
@@ -60,6 +60,7 @@ class TypeTreeGenerator(TypeTreeGeneratorBase):
             0,
             0,
             m_MetaFlag=base_root.m_MetaFlag,
+            m_Children=base_node.m_Children[:],
         )
         stack: List[TypeTreeNode] = []
         parent = root


### PR DESCRIPTION
Complementary PR to https://github.com/UnityPy-Org/TypeTreeGeneratorAPI/pull/4

This should make all backends usable, whereas previously only the `AssetStudio` backend would include monobehaviour base fields.

Now, the generator generates only the script fields, and `UnityPy` prepends the fields.

Needs a version bump of the generator when that is released.