### PR TITLE
Refactor MeshHelper

### DIFF
--- a/UnityPy/helpers/MeshHelper.py
+++ b/UnityPy/helpers/MeshHelper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import struct
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
 
 from ..classes.generated import (
     ChannelInfo,
@@ -33,12 +33,6 @@ except ImportError:
 Tuple2f = Tuple[float, float]
 Tuple3f = Tuple[float, float, float]
 Tuple4f = Tuple[float, float, float, float]
-
-T = TypeVar("T")
-
-
-def flat_list_to_tuples(data: Sequence[T], item_size: int) -> List[tuple[T, ...]]:
-    return [tuple(data[i : i + item_size]) for i in range(0, len(data), item_size)]
 
 
 def vector_list_to_tuples(
@@ -403,7 +397,10 @@ class MeshHandler:
 
                 count = len(componentBytes) // component_byte_size
                 component_data = struct.unpack(f">{count}{component_dtype}", componentBytes)
-                component_data = flat_list_to_tuples(component_data, channel_dimension)
+                component_data = [
+                    tuple(component_data[i : i + channel_dimension])
+                    for i in range(0, len(component_data), channel_dimension)
+                ]
 
                 self.assign_channel_vertex_data(chn, component_data)
 


### PR DESCRIPTION
### Summary

This PR does some improvements to MeshHelper.

1. Making `flat_list_to_tuples` an inline function.
2. Introduces the `lists_to_tuples` function to fix the type error that `List[List]` produced by the `zeros` function cannot be assigned to tuple-member-lists such as `List[Tuple3f]` `List[Tuple4f]`.
3. Refactors the `get_triangles` function.
   1. Changes the way to generate triangles lists.
   2. Adds a `indexCount` fix for TriangleStrip submeshes, see [AssetStudio's code](https://github.com/aelurum/AssetStudio/blob/7b7eac62d80c8ef9a596cac7df727a2c81044a9f/AssetStudio/Classes/Mesh.cs#L1179).
   3. Removes the TODOs in the `get_triangles` function (I have tested that using NumPy `as_strided` function cannot realize a speed-up).
