### PR TITLE
MeshHandler: Fix `weightsData` dequantization error

### DIFF
--- a/UnityPy/helpers/MeshHelper.py
+++ b/UnityPy/helpers/MeshHelper.py
@@ -583,7 +583,6 @@ class MeshHandler:
         # Skin
         if m_CompressedMesh.m_Weights.m_NumItems > 0:
             weightsData = unpack_ints(m_CompressedMesh.m_Weights)
-            weightsData = [weight for weight in weightsData]
             boneIndicesData = unpack_ints(m_CompressedMesh.m_BoneIndices)
 
             vertexIndex = 0


### PR DESCRIPTION
In the Editor's serialization code, normalized weights are quantized as 5-bit fixed point UNORM values then packed as ints.

 This implies flooring - while the sum of the quantized values are guaranteed to be `31` this can lead to a loss of precision where the *de*quantized sum (div by 31 then sum) of weights is not correct with IEEE float.

Such cases can be trivally reproduced by search, for example a tuple of $$(1,25,5)$$ summed as $$(\frac{1}{31}+\frac{25}{31}+\frac{5}{31}$$ in _that exact order_ will yield $$0.9999999999999999$$ instead of $$1.0$$, and `((1/31+25/31+5/31) >= 1.0)` in Python interperter will evalutate as `False`.

This PR implements the sum of weight with ints instead. Alternatively an epsilon value could be chosen, but this is what the player code does.

Attachments in https://github.com/K0lb3/UnityPy/issues/333 can reproduce this issue. See screenshots below.

- Before patch:
<img width="2875" height="1767" alt="image" src="https://github.com/user-attachments/assets/51cc3be1-d1e6-4a3b-828b-58aa52afe30a" />

- After patch:
<img width="2735" height="1763" alt="image" src="https://github.com/user-attachments/assets/c32468fd-800d-4a18-a629-226127c3c372" />
