### PR TITLE
feat: Lock-free ASTC codec operations

### DIFF
--- a/UnityPy/export/Texture2DConverter.py
+++ b/UnityPy/export/Texture2DConverter.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import struct
 from io import BytesIO
-from threading import Lock
+from functools import lru_cache
+from threading import get_ident
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import astc_encoder
@@ -108,9 +109,8 @@ def compress_astc(data: bytes, width: int, height: int, target_texture_format: T
     assert block_size is not None, f"failed to get block size for {target_texture_format.name}"
     swizzle = astc_encoder.ASTCSwizzle.from_str("RGBA")
 
-    context, lock = get_astc_context(block_size)
-    with lock:
-        enc_img = context.compress(astc_image, swizzle)
+    context = get_astc_context(block_size)
+    enc_img = context.compress(astc_image, swizzle)
 
     return enc_img
 
@@ -359,32 +359,31 @@ def astc(image_data: bytes, width: int, height: int, block_size: tuple) -> Image
     if len(image_data) < texture_size:
         raise ValueError(f"Invalid ASTC data size: {len(image_data)} < {texture_size}")
 
-    context, lock = get_astc_context(block_size)
-    with lock:
-        context.decompress(image_data[:texture_size], image, astc_encoder.ASTCSwizzle.from_str("RGBA"))
+    context = get_astc_context(block_size)
+    context.decompress(image_data[:texture_size], image, astc_encoder.ASTCSwizzle.from_str("RGBA"))
     assert image.data is not None, "Decompression failed, image data is None"
 
     return Image.frombytes("RGBA", (width, height), image.data, "raw", "RGBA")
 
 
-ASTC_CONTEXTS: Dict[Tuple[int, int], Tuple[astc_encoder.ASTCContext, Lock]] = {}
-
+@lru_cache(maxsize=128)
+def _get_astc_context(ident: int, block_size: tuple):
+    config = astc_encoder.ASTCConfig(
+        astc_encoder.ASTCProfile.LDR,
+        *block_size,
+        block_z=1,
+        quality=100,
+        flags=astc_encoder.ASTCConfigFlags.USE_DECODE_UNORM8,
+    )
+    context = astc_encoder.ASTCContext(config)
+    return context    
 
 def get_astc_context(block_size: tuple):
-    """Get the ASTC context and its lock using the given `block_size`."""
-    if block_size not in ASTC_CONTEXTS:
-        config = astc_encoder.ASTCConfig(
-            astc_encoder.ASTCProfile.LDR,
-            *block_size,
-            block_z=1,
-            quality=100,
-            flags=astc_encoder.ASTCConfigFlags.USE_DECODE_UNORM8,
-        )
-        context = astc_encoder.ASTCContext(config)
-        lock = Lock()
-        ASTC_CONTEXTS[block_size] = (context, lock)
-    return ASTC_CONTEXTS[block_size]
-
+    """Get the ASTC context for the current thread using the given `block_size`.
+    Created contexts belong to and only to the calling thread, and may be cached.
+    This function is thread safe.
+    """
+    return _get_astc_context(get_ident(), block_size)
 
 def calculate_astc_compressed_size(width: int, height: int, block_size: tuple) -> int:
     """Calculate the size of the compressed data for ASTC."""


### PR DESCRIPTION
This PR removes the explict locking in ASTC related codec routines in favor of per-thread allocation instead.

For ST workloads this changes nothing - contexts will still be cached and is cheap to reuse. 

For MT the extra allocation will grow with calling threads - though may be reused as per [get_ident() docs](https://docs.python.org/3/library/threading.html#threading.get_ident). `functools.lru_cache` is used to mitigate potential leaks here.

This applies to both encoding and decoding processes.

## Addenum: Benchmark

- Code
```python

def test_encode(size):
    from UnityPy.export.Texture2DConverter import compress_astc, TextureFormat
    img = bytes(4 * size * size)
    compress_astc(img, size, size, TextureFormat.ASTC_RGB_6x6)

def test(executor, size, jobs, workers):
    for res in executor.map(test_encode, [size] * jobs):
        pass # Gather all results before returning

if __name__ == "__main__":
    t_repeat = 8
    t_number = 16
    size = 512
    jobs = 128
    max_workers = 6

    import timeit
    from concurrent.futures import ThreadPoolExecutor
    for workers in range(1, max_workers + 1):
        with ThreadPoolExecutor(max_workers=workers) as executor:
            times = timeit.repeat("test(executor, size, jobs, workers)", globals=globals(), number=t_number, repeat=t_repeat)     
            print(f'ThreadPool n={t_number} workers={workers} avg: {sum(times) / len(times)}')
  ```
  
  - Results (https://github.com/K0lb3/UnityPy/commit/a52f70d1020ba0e1b5325626070b433c31c8d22a)
  ```bash
ThreadPool n=16 workers=1 avg: 1.6013365874994179
ThreadPool n=16 workers=2 avg: 1.8349196000001484
ThreadPool n=16 workers=3 avg: 1.7442084625001826
ThreadPool n=16 workers=4 avg: 1.7662892000000738
ThreadPool n=16 workers=5 avg: 1.7565655249998144
ThreadPool n=16 workers=6 avg: 1.7495201125002495
```
- Results (This PR)
```bash
ThreadPool n=16 workers=1 avg: 1.7571594624998852
ThreadPool n=16 workers=2 avg: 0.9583396875002563
ThreadPool n=16 workers=3 avg: 0.6424626125001396
ThreadPool n=16 workers=4 avg: 0.514299999999821
ThreadPool n=16 workers=5 avg: 0.44599136250030824
ThreadPool n=16 workers=6 avg: 0.43532513749960344
```
