### PR TITLE
Fix UnityFS block info flags when saving bundles

### DIFF
--- a/UnityPy/files/BundleFile.py
+++ b/UnityPy/files/BundleFile.py
@@ -215,7 +215,7 @@ class BundleFile(File.File):
             self.save_web_raw(writer)
         elif self.signature == "UnityFS":
             if not packer or packer == "none":
-                self.save_fs(writer, 64, 64)
+                self.save_fs(writer, 0x40, 0)
             elif packer == "original":
                 self.save_fs(
                     writer,
@@ -282,6 +282,9 @@ class BundleFile(File.File):
 
         # file list & file data
         # prep nodes and build up block data
+        data_flag = int(data_flag)
+        block_info_flag = int(block_info_flag) & 0x3F
+
         data_writer = EndianBinaryWriter()
         files = [
             (
@@ -316,7 +319,7 @@ class BundleFile(File.File):
             # compressed size
             block_writer.write_u_int(block_compressed_size)
             # flag
-            block_writer.write_u_short(block_flag)
+            block_writer.write_u_short(block_flag & 0x3F)
 
         # file block info
         if not data_flag & 0x40:


### PR DESCRIPTION
# Problem
  Saving UnityFS bundles with UnityPy could produce corrupted block info metadata. In some cases (e.g., Unity 2019.3.x),
  UnityPy wrote header-only flags into block info entries. This could cause block info size/parsing mismatches on reload
  and lead to struct.error during BundleFile.read_fs().

# Root cause:
  save() passed block_info_flag=64 for the “none” packer, and save_fs() used that flag directly for block info entries.
  The 0x40 bit is a header/layout flag (BlocksAndDirectoryInfoCombined) and should not appear in block info compression
  flags. Block info entries should only carry compression-type bits (0x3F).

# Changes:
  - Default “none” packer now uses data_flag=0x40 and block_info_flag=0.
  - save_fs() masks block_info_flag with 0x3F before building block info.
  - Each block info entry writes block_flag & 0x3F.

# Impact:
  - Prevents invalid block info flags from being written.
  - Fixes reload failures caused by block info size mismatches.
  - Behavior is unchanged for original, lz4, and lzma packers except for safe masking.

# Testing:
  - Reproduced load failure on Unity 2019.3.x AssetBundle when saved with packer="none".
  - After the fix, saved bundles reload successfully with UnityPy.