### PR TITLE
[TESTS] Add global random seed for deterministic test

### DIFF
--- a/tests/test_typetree.py
+++ b/tests/test_typetree.py
@@ -13,6 +13,7 @@ from UnityPy.helpers.TypeTreeNode import TypeTreeNode
 from UnityPy.helpers.UnityVersion import UnityVersion
 from UnityPy.streams import EndianBinaryReader, EndianBinaryWriter
 
+random.seed(17)
 PROCESS = psutil.Process(os.getpid())
 
 


### PR DESCRIPTION
## Description

This PR sets a fixed global random seed after imports in the test file to ensure deterministic and reproducible test behavior.

## Motivation

Some tests rely on randomness without a fixed seed, which can lead to flaky tests, inconsistent CI results, and difficulty reproducing failures.

## Change

A global random seed is initialized to make random behavior consistent across test runs.

## Benefits

- More reproducible and reliable tests  
- Easier debugging of failures  
- Consistent CI behavior  

The issue was identified during an ongoing research project.