### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/UnityPy/helpers/TypeTreeGenerator.py
+++ b/UnityPy/helpers/TypeTreeGenerator.py
@@ -30,8 +30,10 @@ class TypeTreeGenerator(TypeTreeGeneratorBase):
         if "GameAssembly.dll" in root_files:
             ga_fp = os.path.join(root_dir, "GameAssembly.dll")
             gm_fp = os.path.join(data_dir, "il2cpp_data", "Metadata", "global-metadata.dat")
-            ga_raw = open(ga_fp, "rb").read()
-            gm_raw = open(gm_fp, "rb").read()
+            with open(ga_fp, "rb") as f:
+                ga_raw = f.read()
+            with open(gm_fp, "rb") as f:
+                gm_raw = f.read()
             self.load_il2cpp(ga_raw, gm_raw)
         else:
             self.load_local_dll_folder(os.path.join(data_dir, "Managed"))


### PR DESCRIPTION
This pull request fixes a file-handling issue in the helper methods. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python's garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.