### PR TITLE
Order written objects by `path_id`

### DIFF
--- a/UnityPy/files/SerializedFile.py
+++ b/UnityPy/files/SerializedFile.py
@@ -413,7 +413,7 @@ class SerializedFile(File.File):
 
         # ReadObjects
         meta_writer.write_int(len(self.objects))
-        for obj in self.objects.values():
+        for obj in sorted(self.objects.values(), key=lambda x: x.path_id):
             obj.write(header, meta_writer, data_writer)
             data_writer.align_stream(8)
 


### PR DESCRIPTION
Discovered by nesrak1, from discussion on the the Discord: https://discord.com/channels/603359898507673630/1407381658151292988/1468551292400959598

Unity requires the written objects to be sorted by `path_id` sequentially.
Newer Unity versions seem to work with a scrambled order, but older versions like `2018.4.2f1` will refuse to load objects that are written out of order.
Since dictionaries in python maintain insertion order, if a new object is added to the dictionary, it will be appended to the very end, meaning any freshly inserted objects with a new `path_id` will not load correctly in older Unity versions.

I'm not sure about the performance impact here with larger bundle files, if it does become an issue there might be ways to ensure the correct order on insertion (not sure if a dictionary is the correct backing structure for that though.)