### PR TITLE
Checking for python version for the open_binary and files calls

### DIFF
--- a/UnityPy/helpers/Tpk.py
+++ b/UnityPy/helpers/Tpk.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from enum import IntEnum, IntFlag
 from io import BytesIO
 from struct import Struct
@@ -17,22 +18,22 @@ NODES_CACHE: Dict[TpkUnityClass, TypeTreeNode] = {}
 
 
 def init():
-    try:
+    package = "UnityPy.resources"
+    resource = "lzma.tpk"
+
+    tpk_data: bytes
+    if sys.version_info >= (3, 9):
         from importlib.resources import files
 
-        def open_resource(package, resource):
-            return files(package).joinpath(resource).open("rb").read()
-            
-    except ImportError:
+        tpk_data = files(package).joinpath(resource).read_bytes()
+
+    else:
         from importlib.resources import open_binary
 
-        def open_resource(package, resource):
-            return open_binary(package, resource).read()
-                
-    data = open_resource("UnityPy.resources", "lzma.tpk")
+        tpk_data = open_binary(package, resource).read()
 
     global TPKTYPETREE
-    with BytesIO(data) as stream:
+    with BytesIO(tpk_data) as stream:
         blob = TpkFile(stream).GetDataBlob()
         assert isinstance(blob, TpkTypeTreeBlob)
         TPKTYPETREE = blob

--- a/UnityPy/helpers/Tpk.py
+++ b/UnityPy/helpers/Tpk.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import IntEnum, IntFlag
-from importlib.resources import open_binary
 from io import BytesIO
 from struct import Struct
 from typing import Any, Dict, List, Optional, Tuple, TypeVar
@@ -18,8 +17,19 @@ NODES_CACHE: Dict[TpkUnityClass, TypeTreeNode] = {}
 
 
 def init():
-    with open_binary("UnityPy.resources", "lzma.tpk") as f:
-        data = f.read()
+    try:
+        from importlib.resources import files
+
+        def open_resource(package, resource):
+            return files(package).joinpath(resource).open("rb").read()
+            
+    except ImportError:
+        from importlib.resources import open_binary
+
+        def open_resource(package, resource):
+            return open_binary(package, resource).read()
+                
+    data = open_resource("UnityPy.resources", "lzma.tpk")
 
     global TPKTYPETREE
     with BytesIO(data) as stream:


### PR DESCRIPTION
I just wanted to fix the warning "DeprecationWarning".
So i just added a check for python version. If the python version is >= 3.9, then is going to use files call.
If not, is going to fallback to open_binary.

Is not much, but i hope it helps :D